### PR TITLE
refactor: rebrand to EDC Connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
-  <h1>EDC Client 👩‍🚀</h1>
+  <h1>EDC Connector Client 👩‍🚀</h1>
   <p>
     <b>
-      A HTTP client to communicate with the <a href="https://github.com/eclipse-dataspaceconnector/DataSpaceConnector">Eclipse Dataspace Connector</a> for Node.js and the browser.
+      A HTTP client to communicate with the <a href="https://github.com/eclipse-edc/Connector">EDC Connector</a> for Node.js and the browser.
     </b>
   </p>
   <sub>
@@ -12,54 +12,65 @@
 
 ## Abstract
 
-// TODO
+The [**EDC Connector**](https://github.com/eclipse-edc/Connector) is a framework for a sovereign, inter-organizational
+data exchange. It provides _low-level_ primitives to allow network participants to expose and consume offers.
+The _Connector_ does so by providing an extensive HTTP API documented via
+[OpenAPI specification](https://github.com/eclipse-edc/Connector/blob/0366295879b133756f534b4138257722c341cde5/resources/openapi/openapi.yaml).
 
-> Similarly as for the ECC, this library is at its early stage.
-> It aims to maintain compatibility with the lastest version of the _Connector_, and the versioning reflects
-> which version 
+This project aims to increase the level of abstraction, bringing the _low-level_ HTTP API to _mid-level_
+developers by providing an HTTP Client which is thoroughly tested and fully type-safe.
+
+> Similarly to the **EDC Connector**, this library is at its early stage.
+> It aims to maintain compatibility with the latest version of the _Connector_, currently `v0.0.1-milestone-7`.
+> The compatibility is reflected in the library's versioning. The _EDC Connector Client_ follows semver where possible,
+> keeping _major_ and _minor_ related to the **EDC Connector** while _patch_ reserved for library's related fixes.
 
 ## Usage
 
 Install via `npm` or `yarn`
 
 ```sh
-npm install @think-it-labs/edc-client
+npm install @think-it-labs/edc-connector-client
 ```
 
 ```sh
-yarn add @think-it-labs/edc-client
+yarn add @think-it-labs/edc-connector-client
 ```
 
-Then it's possible to create a custom `Error` class extending the `TypedError`
+Once installed, clients can be instanciated by construcing a `EdcConnectorClient`.
 
 ```ts
-import { EdcClient } from "@think-it-labs/edc-client"
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client"
 
-const edcClient = new EdcClient();
+const edcConnectorClient = new EdcConnectorClient();
 
 ```
 
+The `EdcConnectorClient` is connector-agnostic; hence it doesn't know nor store
+connectors' token and addresses. Instead, these are passed to each method through a context
+object, representing a unique connector.
+
 ```ts
 
-const context = edcClient.createContext("123456", {
-  default: "https://default.edc.example.com/",
-  validation: "https://validation.edc.example.com/",
-  data: "https://data.edc.example.com/",
-  ids: "https://ids.edc.example.com/",
-  public: "https://public.edc.example.com/",
-  control: "https://control.edc.example.com/",
+const context = edcConnectorClient.createContext("123456", {
+  default: "https://default.edc.think-it.io/",
+  validation: "https://validation.edc.think-it.io/",
+  data: "https://data.edc.think-it.io/",
+  ids: "https://ids.edc.think-it.io/",
+  dataplane: "https://dataplane.edc.think-it.io/",
+  public: "https://public.edc.think-it.io/",
+  control: "https://control.edc.think-it.io/",
 });
 
-const asset = await edcClient.asset.createAsset(context, {
+const result = await edcConnectorClient.data.createAsset(context, {
   asset: {
     properties: {
-      "asset:prop:id": "urn:asset:a-http-asset",
+      "asset:prop:id": "a-http-asset-id",
       "asset:prop:name": "A HTTP asset",
     }
   },
   dataAddress: {
     properties: {
-      uid: "2",
       name: "An HTTP address",
       baseUrl: "https://example.com/",
       type: "HttpData",
@@ -72,26 +83,29 @@ const asset = await edcClient.asset.createAsset(context, {
 
 ```
 
-Now, during error handling code can inspect the `type` error and define behaviour accordingly
+All API methods are _type, and error-safe_, which means arguments are fully typed
+with [TypeScript](https://www.typescriptlang.org/), and thrown errors are always
+`EdcConnectorClientError` instances. This error safety level is achieved using the
+[`TypedError`](https://github.com/Think-iT-Labs/typed-error) library. 
 
 ```ts
 
-import { EdcClientError, EdcClientErrorType } from "@think-it-labs/edc-client"
+import { EdcConnectorClientError, EdcConnectorClientErrorType } from "@think-it-labs/edc-connector-client"
 
 try {
   
-  // perform async EdcClient actions
+  // perform async EdcConnectorClient actions
   
 } catch(error) {
-  if (error instanceof EdcClientError) {
+  if (error instanceof EdcConnectorClientError) {
     switch (error.type) {
-      case EdcClientErrorType.Duplicate: {
+      case EdcConnectorClientErrorType.Duplicate: {
         // handle duplicate error
       }
       
       // ...
       
-      case EdcClientErrorType.Unknown:
+      case EdcConnectorClientErrorType.Unknown:
       default: {
         // red alert: unknown behaviour
       }
@@ -100,6 +114,9 @@ try {
 }
 
 ```
+
+> **Note** if you encounter an `Unknown` error you should report this behaviour
+> along steps to reproduce it. `Unknown` behaviours are unwanted and must be fixed asap.
 
 ## Development
 
@@ -111,6 +128,6 @@ try {
 
 ## License
 
-_EdcClient_ is distributed under the terms of the MIT license.
+_EdcConnectorClient_ is distributed under the terms of the MIT license.
 
 See [LICENSE](LICENSE) for details.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@think-it-labs/edc-client",
+  "name": "@think-it-labs/edc-connector-client",
   "version": "0.0.1-milestone-7.beta-1",
-  "description": "Eclipse Dataspace Connector HTTP client",
+  "description": "EDC Connector HTTP client",
   "private": false,
   "main": "src/index.js",
   "typings": "src/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { EdcClientContext } from "./context";
+import { EdcConnectorClientContext } from "./context";
 import {
   DataController,
   DataplaneController,
@@ -9,7 +9,7 @@ import { Inner } from "./inner";
 
 import { version } from "../package.json";
 
-export class EdcClient {
+export class EdcConnectorClient {
   readonly data: DataController;
   readonly dataplane: DataplaneController;
   readonly observability: ObservabilityController;
@@ -22,8 +22,11 @@ export class EdcClient {
     this.observability = new ObservabilityController(inner);
   }
 
-  createContext(token: string, addresses: Addresses): EdcClientContext {
-    return new EdcClientContext(token, addresses);
+  createContext(
+    token: string,
+    addresses: Addresses,
+  ): EdcConnectorClientContext {
+    return new EdcConnectorClientContext(token, addresses);
   }
 
   static version(): string {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import { Addresses } from "./entities";
 
-export class EdcClientContext implements Addresses {
+export class EdcConnectorClientContext implements Addresses {
   #apiToken: string;
   #addresses: Addresses;
 

--- a/src/controllers/data-controller.ts
+++ b/src/controllers/data-controller.ts
@@ -1,4 +1,4 @@
-import { EdcClientContext } from "../context";
+import { EdcConnectorClientContext } from "../context";
 import {
   Asset,
   AssetInput,
@@ -27,7 +27,7 @@ export class DataController {
   }
 
   async createAsset(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: AssetInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
@@ -39,7 +39,7 @@ export class DataController {
   }
 
   async deleteAsset(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     assetId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
@@ -49,7 +49,10 @@ export class DataController {
     });
   }
 
-  async getAsset(context: EdcClientContext, assetId: string): Promise<Asset> {
+  async getAsset(
+    context: EdcConnectorClientContext,
+    assetId: string,
+  ): Promise<Asset> {
     return this.#inner.request(context.data, {
       path: `/api/v1/data/assets/${assetId}`,
       method: "GET",
@@ -57,7 +60,7 @@ export class DataController {
     });
   }
 
-  async listAssets(context: EdcClientContext): Promise<Asset[]> {
+  async listAssets(context: EdcConnectorClientContext): Promise<Asset[]> {
     return this.#inner.request(context.data, {
       path: "/api/v1/data/assets",
       method: "GET",
@@ -66,7 +69,7 @@ export class DataController {
   }
 
   async createPolicy(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: PolicyDefinitionInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
@@ -78,7 +81,7 @@ export class DataController {
   }
 
   async deletePolicy(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     policyId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
@@ -89,7 +92,7 @@ export class DataController {
   }
 
   async getPolicy(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     policyId: string,
   ): Promise<PolicyDefinition> {
     return this.#inner.request(context.data, {
@@ -100,7 +103,7 @@ export class DataController {
   }
 
   async queryAllPolicies(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<PolicyDefinition[]> {
     return this.#inner.request(context.data, {
@@ -112,7 +115,7 @@ export class DataController {
   }
 
   async createContractDefinition(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: ContractDefinitionInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
@@ -124,7 +127,7 @@ export class DataController {
   }
 
   async deleteContractDefinition(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     contractDefinitionId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
@@ -135,7 +138,7 @@ export class DataController {
   }
 
   async getContractDefinition(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     contractDefinitionId: string,
   ): Promise<ContractDefinition> {
     return this.#inner.request(context.data, {
@@ -146,7 +149,7 @@ export class DataController {
   }
 
   async queryAllContractDefinitions(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractDefinition[]> {
     return this.#inner.request(context.data, {
@@ -158,7 +161,7 @@ export class DataController {
   }
 
   async requestCatalog(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: CatalogRequest,
   ): Promise<Catalog> {
     return this.#inner.request(context.data, {
@@ -170,7 +173,7 @@ export class DataController {
   }
 
   async initiateContractNegotiation(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: ContractNegotiationRequest,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
@@ -182,7 +185,7 @@ export class DataController {
   }
 
   async queryNegotiations(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractNegotiation[]> {
     return this.#inner.request(context.data, {
@@ -194,7 +197,7 @@ export class DataController {
   }
 
   async getNegotiation(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractNegotiation> {
     return this.#inner.request(context.data, {
@@ -205,7 +208,7 @@ export class DataController {
   }
 
   async getNegotiationState(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractNegotiationState> {
     return this.#inner.request(context.data, {
@@ -216,7 +219,7 @@ export class DataController {
   }
 
   async cancelNegotiation(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
@@ -227,7 +230,7 @@ export class DataController {
   }
 
   async declineNegotiation(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
@@ -238,7 +241,7 @@ export class DataController {
   }
 
   async getAgreementForNegotiation(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractAgreement> {
     return this.#inner.request(context.data, {
@@ -249,7 +252,7 @@ export class DataController {
   }
 
   async queryAllAgreements(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractAgreement[]> {
     return this.#inner.request(context.data, {
@@ -261,7 +264,7 @@ export class DataController {
   }
 
   async getAgreement(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     agreementId: string,
   ): Promise<ContractAgreement> {
     return this.#inner.request(context.data, {
@@ -272,7 +275,7 @@ export class DataController {
   }
 
   async initiateTransfer(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: TransferProcessInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
@@ -284,7 +287,7 @@ export class DataController {
   }
 
   async queryAllTransferProcesses(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<TransferProcess[]> {
     return this.#inner.request(context.data, {

--- a/src/controllers/dataplane-controller.ts
+++ b/src/controllers/dataplane-controller.ts
@@ -1,5 +1,5 @@
 import { Dataplane, DataplaneInput } from "../entities";
-import { EdcClientContext } from "../context";
+import { EdcConnectorClientContext } from "../context";
 import { Inner } from "../inner";
 
 export class DataplaneController {
@@ -10,7 +10,7 @@ export class DataplaneController {
   }
 
   async registerDataplane(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
     input: DataplaneInput,
   ): Promise<void> {
     return this.#inner.request(context.dataplane, {
@@ -22,7 +22,7 @@ export class DataplaneController {
   }
 
   async listDataplanes(
-    context: EdcClientContext,
+    context: EdcConnectorClientContext,
   ): Promise<Dataplane[]> {
     return this.#inner.request(context.dataplane, {
       path: "/dataplane/instances",

--- a/src/controllers/observability-controller.ts
+++ b/src/controllers/observability-controller.ts
@@ -1,4 +1,4 @@
-import { EdcClientContext } from "../context";
+import { EdcConnectorClientContext } from "../context";
 import { HealthStatus } from "../entities";
 import { Inner } from "../inner";
 
@@ -9,7 +9,7 @@ export class ObservabilityController {
     this.#inner = inner;
   }
 
-  async checkHealth(context: EdcClientContext): Promise<HealthStatus> {
+  async checkHealth(context: EdcConnectorClientContext): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
       path: "/api/check/health",
       method: "GET",
@@ -17,7 +17,9 @@ export class ObservabilityController {
     });
   }
 
-  async checkLiveness(context: EdcClientContext): Promise<HealthStatus> {
+  async checkLiveness(
+    context: EdcConnectorClientContext,
+  ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
       path: "/api/check/liveness",
       method: "GET",
@@ -25,7 +27,9 @@ export class ObservabilityController {
     });
   }
 
-  async checkReadiness(context: EdcClientContext): Promise<HealthStatus> {
+  async checkReadiness(
+    context: EdcConnectorClientContext,
+  ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
       path: "/api/check/readiness",
       method: "GET",
@@ -33,7 +37,9 @@ export class ObservabilityController {
     });
   }
 
-  async checkStartup(context: EdcClientContext): Promise<HealthStatus> {
+  async checkStartup(
+    context: EdcConnectorClientContext,
+  ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
       path: "/api/check/startup",
       method: "GET",

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,12 +1,13 @@
 import { TypedError } from "@think-it-labs/typed-error";
 import { ApiErrorDetail } from "./entities";
 
-export enum EdcClientErrorType {
+export enum EdcConnectorClientErrorType {
   Unknown = "Unknown",
   Duplicate = "Duplicate",
   NotFound = "NotFound",
 }
 
-export class EdcClientError extends TypedError<EdcClientErrorType> {
+export class EdcConnectorClientError
+  extends TypedError<EdcConnectorClientErrorType> {
   body?: ApiErrorDetail[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./context";
-export * from "./edc-client";
+export * from "./client";
 export * from "./entities";
 export * from "./error";

--- a/src/inner.ts
+++ b/src/inner.ts
@@ -1,4 +1,4 @@
-import { EdcClientError, EdcClientErrorType } from "./error";
+import { EdcConnectorClientError, EdcConnectorClientErrorType } from "./error";
 
 interface InnerRequest {
   path: string;
@@ -41,8 +41,8 @@ export class Inner {
 
       switch (response.status) {
         case 404: {
-          const error = new EdcClientError(
-            EdcClientErrorType.NotFound,
+          const error = new EdcConnectorClientError(
+            EdcConnectorClientErrorType.NotFound,
             "resource not found",
           );
 
@@ -51,8 +51,8 @@ export class Inner {
           throw error;
         }
         case 409: {
-          const error = new EdcClientError(
-            EdcClientErrorType.Duplicate,
+          const error = new EdcConnectorClientError(
+            EdcConnectorClientErrorType.Duplicate,
             "duplicated resource",
           );
 
@@ -61,16 +61,16 @@ export class Inner {
           throw error;
         }
         default: {
-          throw new EdcClientError(
-            EdcClientErrorType.Unknown,
+          throw new EdcConnectorClientError(
+            EdcConnectorClientErrorType.Unknown,
             await response.text(),
           );
         }
       }
     } catch (error) {
-      if (!(error instanceof EdcClientError)) {
-        error = new EdcClientError(
-          EdcClientErrorType.Unknown,
+      if (!(error instanceof EdcConnectorClientError)) {
+        error = new EdcConnectorClientError(
+          EdcConnectorClientErrorType.Unknown,
           "something went wrong",
           { cause: error as Error },
         );

--- a/tests/controllers/data.test.ts
+++ b/tests/controllers/data.test.ts
@@ -3,10 +3,13 @@ import {
   Addresses,
   AssetInput,
   ContractDefinitionInput,
-  EdcClient,
+  EdcConnectorClient,
   PolicyDefinitionInput,
 } from "../../src";
-import { EdcClientError, EdcClientErrorType } from "../../src/error";
+import {
+  EdcConnectorClientError,
+  EdcConnectorClientErrorType,
+} from "../../src/error";
 import {
   createContractAgreement,
   createContractNegotiation,
@@ -50,7 +53,7 @@ describe("DataController", () => {
   describe("edcClient.data.createAsset", () => {
     it("succesfully creates an asset", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const assetInput: AssetInput = {
         asset: {
@@ -82,7 +85,7 @@ describe("DataController", () => {
 
     it("fails creating two assets with the same id", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const assetInput: AssetInput = {
         asset: {
@@ -118,10 +121,10 @@ describe("DataController", () => {
         );
 
       maybeCreateResult.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.Duplicate,
+          EdcConnectorClientErrorType.Duplicate,
         );
       });
     });
@@ -130,7 +133,7 @@ describe("DataController", () => {
   describe("edcClient.data.deleteAsset", () => {
     it("deletes a target asset", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const assetInput: AssetInput = {
         asset: {
@@ -165,7 +168,7 @@ describe("DataController", () => {
 
     it("fails to delete an not existant asset", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -181,10 +184,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -195,7 +198,7 @@ describe("DataController", () => {
   describe("edcClient.data.getAsset", () => {
     it("returns a target asset", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const assetInput: AssetInput = {
         asset: {
@@ -234,7 +237,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant asset", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -250,10 +253,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -262,7 +265,7 @@ describe("DataController", () => {
   describe("edcClient.data.listAssets", () => {
     it("succesfully retuns a list of assets", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const assetInput: AssetInput = {
         asset: {
@@ -304,7 +307,7 @@ describe("DataController", () => {
   describe("edcClient.data.createPolicy", () => {
     it("succesfully creates a new policy", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         id: crypto.randomUUID(),
@@ -324,7 +327,7 @@ describe("DataController", () => {
 
     it("fails creating two policies with the same id", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         id: crypto.randomUUID(),
@@ -348,10 +351,10 @@ describe("DataController", () => {
         );
 
       maybeCreateResult.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.Duplicate,
+          EdcConnectorClientErrorType.Duplicate,
         );
       });
     });
@@ -360,7 +363,7 @@ describe("DataController", () => {
   describe("edcClient.data.queryAllPolicies", () => {
     it("succesfully retuns a list of assets", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         id: crypto.randomUUID(),
@@ -387,7 +390,7 @@ describe("DataController", () => {
   describe("edcClient.data.getPolicy", () => {
     it("succesfully retuns a target policy", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         id: crypto.randomUUID(),
@@ -410,7 +413,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant policy", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -426,10 +429,10 @@ describe("DataController", () => {
         );
 
       maybePolicy.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -438,7 +441,7 @@ describe("DataController", () => {
   describe("edcClient.data.deletePolicy", () => {
     it("deletes a target policy", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         id: crypto.randomUUID(),
@@ -461,7 +464,7 @@ describe("DataController", () => {
 
     it("fails to delete an not existant policy", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -477,10 +480,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -491,7 +494,7 @@ describe("DataController", () => {
   describe("edcClient.data.createContractDefinition", () => {
     it("succesfully creates a new contract definition", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         id: crypto.randomUUID(),
@@ -513,7 +516,7 @@ describe("DataController", () => {
 
     it("fails creating two contract definitions with the same id", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         id: crypto.randomUUID(),
@@ -539,10 +542,10 @@ describe("DataController", () => {
         );
 
       maybeCreateResult.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.Duplicate,
+          EdcConnectorClientErrorType.Duplicate,
         );
       });
     });
@@ -551,7 +554,7 @@ describe("DataController", () => {
   describe("edcClient.data.queryAllContractDefinitions", () => {
     it("succesfully retuns a list of contract definitions", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         id: crypto.randomUUID(),
@@ -580,7 +583,7 @@ describe("DataController", () => {
   describe("edcClient.data.getContractDefinition", () => {
     it("succesfully retuns a target contract definition", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         id: crypto.randomUUID(),
@@ -605,7 +608,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant contract definition", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -621,10 +624,10 @@ describe("DataController", () => {
         );
 
       maybePolicy.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -633,7 +636,7 @@ describe("DataController", () => {
   describe("edcClient.data.deleteContractDefinition", () => {
     it("deletes a target contract definition", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         id: crypto.randomUUID(),
@@ -658,7 +661,7 @@ describe("DataController", () => {
 
     it("fails to delete an not existant contract definition", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -674,10 +677,10 @@ describe("DataController", () => {
         );
 
       maybeContractDefinition.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -690,7 +693,7 @@ describe("DataController", () => {
   describe("edcClient.data.requestCatalog", () => {
     it("returns the catalog for a target provider", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const assetId = crypto.randomUUID();
@@ -790,7 +793,7 @@ describe("DataController", () => {
 
     it("kickstart a contract negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
 
@@ -810,7 +813,7 @@ describe("DataController", () => {
   describe("edcClient.data.queryNegotiations", () => {
     it("retrieves all contract negotiations", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { createResult } = await createContractNegotiation(
@@ -835,7 +838,7 @@ describe("DataController", () => {
 
     it("filters negotiations on the provider side based on agreements' assed ID", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { assetId } = await createContractAgreement(
@@ -866,7 +869,7 @@ describe("DataController", () => {
   describe("edcClient.data.getNegotiation", () => {
     it("retrieves target contract negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { createResult } = await createContractNegotiation(
@@ -887,7 +890,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant contract negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -903,10 +906,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -915,7 +918,7 @@ describe("DataController", () => {
   describe("edcClient.data.getNegotiationState", () => {
     it("returns the state of a target negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { createResult } = await createContractNegotiation(
@@ -936,7 +939,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant contract negotiation's state", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -952,10 +955,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -964,7 +967,7 @@ describe("DataController", () => {
   describe("edcClient.data.cancelNegotiation", () => {
     it("cancel the a requested target negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { createResult } = await createContractNegotiation(
@@ -997,7 +1000,7 @@ describe("DataController", () => {
 
     it("fails to cancel an not existant contract negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -1013,10 +1016,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -1025,7 +1028,7 @@ describe("DataController", () => {
   describe.skip("edcClient.data.declineNegotiation", () => {
     it("declines the a requested target negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { assetId, createResult } = await createContractNegotiation(
@@ -1080,7 +1083,7 @@ describe("DataController", () => {
   describe("edcClient.data.getAgreementForNegotiation", () => {
     it("returns the a agreement for a target negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { assetId, createResult } = await createContractNegotiation(
@@ -1113,7 +1116,7 @@ describe("DataController", () => {
   describe("edcClient.data.queryAllAgreements", () => {
     it("retrieves all contract agreements", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { createResult } = await createContractNegotiation(
@@ -1150,7 +1153,7 @@ describe("DataController", () => {
   describe("edcClient.data.getAgreement", () => {
     it("retrieves target contract agreement", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
 
@@ -1171,7 +1174,7 @@ describe("DataController", () => {
 
     it("fails to fetch an not existant contract negotiation", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
@@ -1187,10 +1190,10 @@ describe("DataController", () => {
         );
 
       maybeAsset.catch((error) => {
-        expect(error).toBeInstanceOf(EdcClientError);
-        expect(error as EdcClientError).toHaveProperty(
+        expect(error).toBeInstanceOf(EdcConnectorClientError);
+        expect(error as EdcConnectorClientError).toHaveProperty(
           "type",
-          EdcClientErrorType.NotFound,
+          EdcConnectorClientErrorType.NotFound,
         );
       });
     });
@@ -1199,7 +1202,7 @@ describe("DataController", () => {
   describe("edcClient.data.initiateTransfer", () => {
     it("initiate the transfer process", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { assetId, contractAgreement } = await createContractAgreement(
@@ -1236,7 +1239,7 @@ describe("DataController", () => {
   describe("edcClient.data.queryAllTransferProcesses", () => {
     it("retrieves all tranfer processes", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const consumerContext = edcClient.createContext(apiToken, consumer);
       const providerContext = edcClient.createContext(apiToken, provider);
       const { assetId, contractAgreement } = await createContractAgreement(

--- a/tests/controllers/dataplane.test.ts
+++ b/tests/controllers/dataplane.test.ts
@@ -1,4 +1,4 @@
-import { Addresses, EdcClient } from "../../src";
+import { Addresses, EdcConnectorClient } from "../../src";
 
 describe("DataController", () => {
   const apiToken = "123456";
@@ -15,7 +15,7 @@ describe("DataController", () => {
   describe("edcClient.dataplane.registerDataplane", () => {
     it("succesfully register a dataplane", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
       const dataplaneInput = {
         "edctype": "dataspaceconnector:dataplaneinstance",
@@ -42,7 +42,7 @@ describe("DataController", () => {
   describe("edcClient.dataplane.listDataplanes", () => {
     it("succesfully list available dataplanes", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
       const dataplaneInput = {
         "edctype": "dataspaceconnector:dataplaneinstance",

--- a/tests/controllers/observability.test.ts
+++ b/tests/controllers/observability.test.ts
@@ -1,4 +1,4 @@
-import { Addresses, EdcClient } from "../../src";
+import { Addresses, EdcConnectorClient } from "../../src";
 
 describe("ObservabilityController", () => {
   const apiToken = "123456";
@@ -15,7 +15,7 @@ describe("ObservabilityController", () => {
   describe("edcClient.observability.checkHealth", () => {
     it("succesfully return a HealthStatus response", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
 
       // when
@@ -29,7 +29,7 @@ describe("ObservabilityController", () => {
   describe("edcClient.observability.checkLiveness", () => {
     it("succesfully return a HealthStatus response", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
 
       // when
@@ -43,7 +43,7 @@ describe("ObservabilityController", () => {
   describe("edcClient.observability.checkReadiness", () => {
     it("succesfully return a HealthStatus response", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
 
       // when
@@ -59,7 +59,7 @@ describe("ObservabilityController", () => {
   describe("edcClient.observability.checkStartup", () => {
     it("succesfully return a HealthStatus response", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, addresses);
 
       // when

--- a/tests/edc-client.test.ts
+++ b/tests/edc-client.test.ts
@@ -1,22 +1,22 @@
-import { EdcClient, EdcClientContext } from "../src";
+import { EdcConnectorClient, EdcConnectorClientContext } from "../src";
 import { Addresses } from "../src";
 
-describe("EdcClient", () => {
+describe("EdcConnectorClient", () => {
   it("instantiate a new class", async () => {
     // given
-    const edcClient = new EdcClient();
+    const edcClient = new EdcConnectorClient();
 
     // then
-    expect(edcClient).toBeInstanceOf(EdcClient);
+    expect(edcClient).toBeInstanceOf(EdcConnectorClient);
     expect(edcClient).toHaveProperty("data");
     expect(edcClient).toHaveProperty("dataplane");
     expect(edcClient).toHaveProperty("observability");
   });
 
   describe("edcClient.createContext", () => {
-    it("creates a new EdcClientContext", async () => {
+    it("creates a new EdcConnectorClientContext", async () => {
       // given
-      const edcClient = new EdcClient();
+      const edcClient = new EdcConnectorClient();
       const apiToken = "123456";
       const addresses: Addresses = {
         default: "http://localhost:19191",
@@ -32,7 +32,7 @@ describe("EdcClient", () => {
       const context = edcClient.createContext(apiToken, addresses);
 
       // then
-      expect(context).toBeInstanceOf(EdcClientContext);
+      expect(context).toBeInstanceOf(EdcConnectorClientContext);
       expect(context.apiToken).toBe(apiToken);
       expect(context.default).toBe(addresses.default);
       expect(context.validation).toBe(addresses.validation);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -8,8 +8,8 @@ import {
   ContractNegotiation,
   ContractOffer,
   CreateResult,
-  EdcClient,
-  EdcClientContext,
+  EdcConnectorClient,
+  EdcConnectorClientContext,
   Policy,
   PolicyDefinitionInput,
   TransferProcessResponse,
@@ -31,9 +31,9 @@ interface ContractAgreementMetadata {
 }
 
 export async function createContractAgreement(
-  client: EdcClient,
-  providerContext: EdcClientContext,
-  consumerContext: EdcClientContext,
+  client: EdcConnectorClient,
+  providerContext: EdcConnectorClientContext,
+  consumerContext: EdcConnectorClientContext,
 ): Promise<ContractAgreementMetadata> {
   const { createResult, ...rest } = await createContractNegotiation(
     client,
@@ -64,9 +64,9 @@ export async function createContractAgreement(
 }
 
 export async function createContractNegotiation(
-  client: EdcClient,
-  providerContext: EdcClientContext,
-  consumerContext: EdcClientContext,
+  client: EdcConnectorClient,
+  providerContext: EdcConnectorClientContext,
+  consumerContext: EdcConnectorClientContext,
 ): Promise<ContractNegotiationMetadata> {
   // Register dataplanes
   client.dataplane.registerDataplane(providerContext, {
@@ -176,8 +176,8 @@ export async function createContractNegotiation(
 }
 
 export async function waitForNegotiationState(
-  client: EdcClient,
-  context: EdcClientContext,
+  client: EdcConnectorClient,
+  context: EdcConnectorClientContext,
   negotiationId: string,
   targetState: string,
   interval = 500,


### PR DESCRIPTION
### Description
Following the [EDC Connector announcement](https://github.com/eclipse-edc/Connector/discussions/2244), it seems fair to adapt the library's name to reflect these changes.

After this PR, the library will be called `@think-it-labs/edc-connector-client`.