### PR TITLE
feat!: include prefix in connector address

### DIFF
--- a/conf/consumer-connector.config/addresses.json
+++ b/conf/consumer-connector.config/addresses.json
@@ -2,10 +2,10 @@
   "uid": "1",
   "name": "consumer.edc.think-it.io",
   "addresses": {
-    "default": "http://localhost:19191",
-    "data": "http://localhost:19193",
-    "ids": "http://consumer-connector:9194",
-    "public": "http://localhost:19291",
-    "control": "http://localhost:19292"
+    "default": "http://localhost:19191/api",
+    "data": "http://localhost:19193/api/v1/data",
+    "ids": "http://consumer-connector:9194/api/v1/ids",
+    "public": "http://localhost:19291/public",
+    "control": "http://localhost:19292/control"
   }
 }

--- a/conf/provider-connector.config/addresses.json
+++ b/conf/provider-connector.config/addresses.json
@@ -2,10 +2,10 @@
   "uid": "2",
   "name": "provider.edc.think-it.io",
   "addresses": {
-    "default": "http://localhost:29191",
-    "data": "http://localhost:29193",
-    "ids": "http://provider-connector:9194",
-    "public": "http://localhost:29291",
-    "control": "http://localhost:29292"
+    "default": "http://localhost:29191/api",
+    "data": "http://localhost:29193/api/v1/data",
+    "ids": "http://provider-connector:9194/api/v1/ids",
+    "public": "http://localhost:29291/public",
+    "control": "http://localhost:29292/control"
   }
 }

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -33,7 +33,7 @@ export class ManagementController {
     input: DataplaneInput,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/instances",
+      path: "/instances",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -44,7 +44,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
   ): Promise<Dataplane[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/instances",
+      path: "/instances",
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -55,7 +55,7 @@ export class ManagementController {
     input: AssetInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/assets",
+      path: "/assets",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -67,7 +67,7 @@ export class ManagementController {
     assetId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/assets/${assetId}`,
+      path: `/assets/${assetId}`,
       method: "DELETE",
       apiToken: context.apiToken,
     });
@@ -78,7 +78,7 @@ export class ManagementController {
     assetId: string,
   ): Promise<Asset> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/assets/${assetId}`,
+      path: `/assets/${assetId}`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -86,7 +86,7 @@ export class ManagementController {
 
   async listAssets(context: EdcConnectorClientContext): Promise<Asset[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/assets",
+      path: "/assets",
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -97,7 +97,7 @@ export class ManagementController {
     input: PolicyDefinitionInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/policydefinitions",
+      path: "/policydefinitions",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -109,7 +109,7 @@ export class ManagementController {
     policyId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/policydefinitions/${policyId}`,
+      path: `/policydefinitions/${policyId}`,
       method: "DELETE",
       apiToken: context.apiToken,
     });
@@ -120,7 +120,7 @@ export class ManagementController {
     policyId: string,
   ): Promise<PolicyDefinition> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/policydefinitions/${policyId}`,
+      path: `/policydefinitions/${policyId}`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -131,7 +131,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<PolicyDefinition[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/policydefinitions/request",
+      path: "/policydefinitions/request",
       method: "POST",
       apiToken: context.apiToken,
       body: query,
@@ -143,7 +143,7 @@ export class ManagementController {
     input: ContractDefinitionInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/contractdefinitions",
+      path: "/contractdefinitions",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -155,7 +155,7 @@ export class ManagementController {
     contractDefinitionId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractdefinitions/${contractDefinitionId}`,
+      path: `/contractdefinitions/${contractDefinitionId}`,
       method: "DELETE",
       apiToken: context.apiToken,
     });
@@ -166,7 +166,7 @@ export class ManagementController {
     contractDefinitionId: string,
   ): Promise<ContractDefinition> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractdefinitions/${contractDefinitionId}`,
+      path: `/contractdefinitions/${contractDefinitionId}`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -177,7 +177,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<ContractDefinition[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/contractdefinitions/request",
+      path: "/contractdefinitions/request",
       method: "POST",
       apiToken: context.apiToken,
       body: query,
@@ -189,7 +189,7 @@ export class ManagementController {
     input: CatalogRequest,
   ): Promise<Catalog> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/catalog/request",
+      path: "/catalog/request",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -201,7 +201,7 @@ export class ManagementController {
     input: ContractNegotiationRequest,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/contractnegotiations",
+      path: "/contractnegotiations",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -213,7 +213,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<ContractNegotiation[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/contractnegotiations/request",
+      path: "/contractnegotiations/request",
       method: "POST",
       apiToken: context.apiToken,
       body: query,
@@ -225,7 +225,7 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractNegotiation> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractnegotiations/${negotiationId}`,
+      path: `/contractnegotiations/${negotiationId}`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -236,7 +236,7 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractNegotiationState> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractnegotiations/${negotiationId}/state`,
+      path: `/contractnegotiations/${negotiationId}/state`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -247,7 +247,7 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractnegotiations/${negotiationId}/cancel`,
+      path: `/contractnegotiations/${negotiationId}/cancel`,
       method: "POST",
       apiToken: context.apiToken,
     });
@@ -258,7 +258,7 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<void> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractnegotiations/${negotiationId}/decline`,
+      path: `/contractnegotiations/${negotiationId}/decline`,
       method: "POST",
       apiToken: context.apiToken,
     });
@@ -269,7 +269,7 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractAgreement> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractnegotiations/${negotiationId}/agreement`,
+      path: `/contractnegotiations/${negotiationId}/agreement`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -280,7 +280,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<ContractAgreement[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/contractagreements/request",
+      path: "/contractagreements/request",
       method: "POST",
       apiToken: context.apiToken,
       body: query,
@@ -292,7 +292,7 @@ export class ManagementController {
     agreementId: string,
   ): Promise<ContractAgreement> {
     return this.#inner.request(context.data, {
-      path: `/api/v1/data/contractagreements/${agreementId}`,
+      path: `/contractagreements/${agreementId}`,
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -303,7 +303,7 @@ export class ManagementController {
     input: TransferProcessInput,
   ): Promise<CreateResult> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/transferprocess",
+      path: "/transferprocess",
       method: "POST",
       apiToken: context.apiToken,
       body: input,
@@ -315,7 +315,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<TransferProcess[]> {
     return this.#inner.request(context.data, {
-      path: "/api/v1/data/transferprocess/request",
+      path: "/transferprocess/request",
       method: "POST",
       apiToken: context.apiToken,
       body: query,

--- a/src/controllers/observability-controller.ts
+++ b/src/controllers/observability-controller.ts
@@ -11,7 +11,7 @@ export class ObservabilityController {
 
   async checkHealth(context: EdcConnectorClientContext): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
-      path: "/api/check/health",
+      path: "/check/health",
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -21,7 +21,7 @@ export class ObservabilityController {
     context: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
-      path: "/api/check/liveness",
+      path: "/check/liveness",
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -31,7 +31,7 @@ export class ObservabilityController {
     context: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
-      path: "/api/check/readiness",
+      path: "/check/readiness",
       method: "GET",
       apiToken: context.apiToken,
     });
@@ -41,7 +41,7 @@ export class ObservabilityController {
     context: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
     return this.#inner.request(context.default, {
-      path: "/api/check/startup",
+      path: "/check/startup",
       method: "GET",
       apiToken: context.apiToken,
     });

--- a/src/controllers/public-controller.ts
+++ b/src/controllers/public-controller.ts
@@ -13,7 +13,7 @@ export class PublicController {
     headers: Record<string, string | undefined>,
   ): Promise<Response> {
     return this.#inner.stream(context.public, {
-      path: "/public",
+      path: "/",
       method: "GET",
       headers,
     });

--- a/src/inner.ts
+++ b/src/inner.ts
@@ -45,7 +45,7 @@ export class Inner {
   }
 
   async #fetch(baseUrl: string, innerRequest: InnerRequest): Promise<Response> {
-    const url = new URL(innerRequest.path, baseUrl);
+    const url = new URL(`${baseUrl}${innerRequest.path}`);
 
     if (innerRequest.query) {
       Object.entries(innerRequest.query).forEach(([key, value]) => {

--- a/tests/controllers/management.test.ts
+++ b/tests/controllers/management.test.ts
@@ -22,18 +22,18 @@ jest.setTimeout(20000);
 describe("DataController", () => {
   const apiToken = "123456";
   const consumer: Addresses = {
-    default: "http://localhost:19191",
-    data: "http://localhost:19193",
-    ids: "http://consumer-connector:9194",
-    public: "http://localhost:19291",
-    control: "http://localhost:19292",
+    default: "http://localhost:19191/api",
+    data: "http://localhost:19193/api/v1/data",
+    ids: "http://consumer-connector:9194/api/v1/ids",
+    public: "http://localhost:19291/public",
+    control: "http://localhost:19292/control",
   };
   const provider: Addresses = {
-    default: "http://localhost:29191",
-    data: "http://localhost:29193",
-    ids: "http://provider-connector:9194",
-    public: "http://localhost:29291",
-    control: "http://localhost:29292",
+    default: "http://localhost:29191/api",
+    data: "http://localhost:29193/api/v1/data",
+    ids: "http://provider-connector:9194/api/v1/ids",
+    public: "http://localhost:29291/public",
+    control: "http://localhost:29292/control",
   };
 
   describe("edcClient.management.createAsset", () => {
@@ -761,7 +761,7 @@ describe("DataController", () => {
       const catalog = await edcClient.management.requestCatalog(
         consumerContext,
         {
-          providerUrl: `${provider.ids}/api/v1/ids/data`,
+          providerUrl: `${provider.ids}/data`,
         },
       );
 
@@ -1227,7 +1227,7 @@ describe("DataController", () => {
           {
             assetId,
             "connectorId": "provider",
-            "connectorAddress": `${providerContext.ids}/api/v1/ids/data`,
+            "connectorAddress": `${providerContext.ids}/data`,
             "contractId": contractAgreement.id,
             "managedResources": false,
             "dataDestination": { "type": "HttpProxy" },
@@ -1263,7 +1263,7 @@ describe("DataController", () => {
           {
             assetId,
             "connectorId": "provider",
-            "connectorAddress": `${providerContext.ids}/api/v1/ids/data`,
+            "connectorAddress": `${providerContext.ids}/data`,
             "contractId": contractAgreement.id,
             "managedResources": false,
             "dataDestination": { "type": "HttpProxy" },

--- a/tests/controllers/observability.test.ts
+++ b/tests/controllers/observability.test.ts
@@ -3,11 +3,11 @@ import { Addresses, EdcConnectorClient } from "../../src";
 describe("ObservabilityController", () => {
   const apiToken = "123456";
   const addresses: Addresses = {
-    default: "http://localhost:19191",
-    data: "http://localhost:19193",
-    ids: "http://localhost:19194",
-    public: "http://localhost:19291",
-    control: "http://localhost:19292",
+    default: "http://localhost:19191/api",
+    data: "http://localhost:19193/api/v1/data",
+    ids: "http://consumer-connector:9194/api/v1/ids",
+    public: "http://localhost:19291/public",
+    control: "http://localhost:19292/control",
   };
 
   describe("edcClient.observability.checkHealth", () => {

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -11,18 +11,18 @@ jest.setTimeout(30000);
 describe("PublicController", () => {
   const apiToken = "123456";
   const consumer: Addresses = {
-    default: "http://localhost:19191",
-    data: "http://localhost:19193",
-    ids: "http://consumer-connector:9194",
-    public: "http://localhost:19291",
-    control: "http://localhost:19292",
+    default: "http://localhost:19191/api",
+    data: "http://localhost:19193/api/v1/data",
+    ids: "http://consumer-connector:9194/api/v1/ids",
+    public: "http://localhost:19291/public",
+    control: "http://localhost:19292/control",
   };
   const provider: Addresses = {
-    default: "http://localhost:29191",
-    data: "http://localhost:29193",
-    ids: "http://provider-connector:9194",
-    public: "http://localhost:29291",
-    control: "http://localhost:29292",
+    default: "http://localhost:29191/api",
+    data: "http://localhost:29193/api/v1/data",
+    ids: "http://provider-connector:9194/api/v1/ids",
+    public: "http://localhost:29291/public",
+    control: "http://localhost:29292/control",
   };
 
   const receiverServer = createReceiverServer();
@@ -78,7 +78,7 @@ describe("PublicController", () => {
         {
           assetId,
           "connectorId": "provider",
-          "connectorAddress": `${providerContext.ids}/api/v1/ids/data`,
+          "connectorAddress": `${providerContext.ids}/data`,
           "contractId": contractAgreement.id,
           "managedResources": false,
           "dataDestination": { "type": "HttpProxy" },

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -146,7 +146,7 @@ export async function createContractNegotiation(
 
   // Retrieve catalog and select contract offer
   const catalog = await client.management.requestCatalog(consumerContext, {
-    providerUrl: `${providerContext.ids}/api/v1/ids/data`,
+    providerUrl: `${providerContext.ids}/data`,
   });
   const contractOffer = catalog.contractOffers.find((offer) =>
     offer.asset?.id === assetId
@@ -155,7 +155,7 @@ export async function createContractNegotiation(
   // Initiate contract negotiation on the consumer's side
   const createResult = await client.management
     .initiateContractNegotiation(consumerContext, {
-      connectorAddress: `${providerContext.ids}/api/v1/ids/data`,
+      connectorAddress: `${providerContext.ids}/data`,
       connectorId: "provider",
       offer: {
         offerId: contractOffer.id as string,


### PR DESCRIPTION
As discussed with @ndr-brt, addresses prefix (i.e. `/api` for default, or `/api/v1/data` for data) should be included in the context's addresses to ensure flexibility to all use cases.