### PR TITLE
feat!: rename data to management and ids to protocol

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -13,12 +13,12 @@ export class EdcConnectorClientContext implements Addresses {
     return this.#addresses.default;
   }
 
-  get ids(): string {
-    return this.#addresses.ids;
+  get protocol(): string {
+    return this.#addresses.protocol;
   }
 
-  get data(): string {
-    return this.#addresses.data;
+  get management(): string {
+    return this.#addresses.management;
   }
 
   get control(): string {

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -32,7 +32,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: DataplaneInput,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/instances",
       method: "POST",
       apiToken: context.apiToken,
@@ -43,7 +43,7 @@ export class ManagementController {
   async listDataplanes(
     context: EdcConnectorClientContext,
   ): Promise<Dataplane[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/instances",
       method: "GET",
       apiToken: context.apiToken,
@@ -54,7 +54,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: AssetInput,
   ): Promise<CreateResult> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/assets",
       method: "POST",
       apiToken: context.apiToken,
@@ -66,7 +66,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     assetId: string,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/assets/${assetId}`,
       method: "DELETE",
       apiToken: context.apiToken,
@@ -77,7 +77,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     assetId: string,
   ): Promise<Asset> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/assets/${assetId}`,
       method: "GET",
       apiToken: context.apiToken,
@@ -85,7 +85,7 @@ export class ManagementController {
   }
 
   async listAssets(context: EdcConnectorClientContext): Promise<Asset[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/assets",
       method: "GET",
       apiToken: context.apiToken,
@@ -96,7 +96,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: PolicyDefinitionInput,
   ): Promise<CreateResult> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/policydefinitions",
       method: "POST",
       apiToken: context.apiToken,
@@ -108,7 +108,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     policyId: string,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/policydefinitions/${policyId}`,
       method: "DELETE",
       apiToken: context.apiToken,
@@ -119,7 +119,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     policyId: string,
   ): Promise<PolicyDefinition> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/policydefinitions/${policyId}`,
       method: "GET",
       apiToken: context.apiToken,
@@ -130,7 +130,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<PolicyDefinition[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/policydefinitions/request",
       method: "POST",
       apiToken: context.apiToken,
@@ -142,7 +142,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: ContractDefinitionInput,
   ): Promise<CreateResult> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/contractdefinitions",
       method: "POST",
       apiToken: context.apiToken,
@@ -154,7 +154,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     contractDefinitionId: string,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractdefinitions/${contractDefinitionId}`,
       method: "DELETE",
       apiToken: context.apiToken,
@@ -165,7 +165,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     contractDefinitionId: string,
   ): Promise<ContractDefinition> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractdefinitions/${contractDefinitionId}`,
       method: "GET",
       apiToken: context.apiToken,
@@ -176,7 +176,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractDefinition[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/contractdefinitions/request",
       method: "POST",
       apiToken: context.apiToken,
@@ -188,7 +188,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: CatalogRequest,
   ): Promise<Catalog> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/catalog/request",
       method: "POST",
       apiToken: context.apiToken,
@@ -200,7 +200,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: ContractNegotiationRequest,
   ): Promise<CreateResult> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/contractnegotiations",
       method: "POST",
       apiToken: context.apiToken,
@@ -212,7 +212,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractNegotiation[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/contractnegotiations/request",
       method: "POST",
       apiToken: context.apiToken,
@@ -224,7 +224,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractNegotiation> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractnegotiations/${negotiationId}`,
       method: "GET",
       apiToken: context.apiToken,
@@ -235,7 +235,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractNegotiationState> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractnegotiations/${negotiationId}/state`,
       method: "GET",
       apiToken: context.apiToken,
@@ -246,7 +246,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractnegotiations/${negotiationId}/cancel`,
       method: "POST",
       apiToken: context.apiToken,
@@ -257,7 +257,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<void> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractnegotiations/${negotiationId}/decline`,
       method: "POST",
       apiToken: context.apiToken,
@@ -268,7 +268,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     negotiationId: string,
   ): Promise<ContractAgreement> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractnegotiations/${negotiationId}/agreement`,
       method: "GET",
       apiToken: context.apiToken,
@@ -279,7 +279,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<ContractAgreement[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/contractagreements/request",
       method: "POST",
       apiToken: context.apiToken,
@@ -291,7 +291,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     agreementId: string,
   ): Promise<ContractAgreement> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: `/contractagreements/${agreementId}`,
       method: "GET",
       apiToken: context.apiToken,
@@ -302,7 +302,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     input: TransferProcessInput,
   ): Promise<CreateResult> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/transferprocess",
       method: "POST",
       apiToken: context.apiToken,
@@ -314,7 +314,7 @@ export class ManagementController {
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
   ): Promise<TransferProcess[]> {
-    return this.#inner.request(context.data, {
+    return this.#inner.request(context.management, {
       path: "/transferprocess/request",
       method: "POST",
       apiToken: context.apiToken,

--- a/src/entities/addresses.ts
+++ b/src/entities/addresses.ts
@@ -1,7 +1,7 @@
 export interface Addresses {
   default: string;
-  data: string;
-  ids: string;
+  management: string;
+  protocol: string;
   public: string;
   control: string;
 }

--- a/tests/controllers/management.test.ts
+++ b/tests/controllers/management.test.ts
@@ -23,15 +23,15 @@ describe("DataController", () => {
   const apiToken = "123456";
   const consumer: Addresses = {
     default: "http://localhost:19191/api",
-    data: "http://localhost:19193/api/v1/data",
-    ids: "http://consumer-connector:9194/api/v1/ids",
+    management: "http://localhost:19193/api/v1/data",
+    protocol: "http://consumer-connector:9194/api/v1/ids",
     public: "http://localhost:19291/public",
     control: "http://localhost:19292/control",
   };
   const provider: Addresses = {
     default: "http://localhost:29191/api",
-    data: "http://localhost:29193/api/v1/data",
-    ids: "http://provider-connector:9194/api/v1/ids",
+    management: "http://localhost:29193/api/v1/data",
+    protocol: "http://provider-connector:9194/api/v1/ids",
     public: "http://localhost:29291/public",
     control: "http://localhost:29292/control",
   };
@@ -761,7 +761,7 @@ describe("DataController", () => {
       const catalog = await edcClient.management.requestCatalog(
         consumerContext,
         {
-          providerUrl: `${provider.ids}/data`,
+          providerUrl: `${provider.protocol}/data`,
         },
       );
 
@@ -1227,7 +1227,7 @@ describe("DataController", () => {
           {
             assetId,
             "connectorId": "provider",
-            "connectorAddress": `${providerContext.ids}/data`,
+            "connectorAddress": `${providerContext.protocol}/data`,
             "contractId": contractAgreement.id,
             "managedResources": false,
             "dataDestination": { "type": "HttpProxy" },
@@ -1263,7 +1263,7 @@ describe("DataController", () => {
           {
             assetId,
             "connectorId": "provider",
-            "connectorAddress": `${providerContext.ids}/data`,
+            "connectorAddress": `${providerContext.protocol}/data`,
             "contractId": contractAgreement.id,
             "managedResources": false,
             "dataDestination": { "type": "HttpProxy" },

--- a/tests/controllers/observability.test.ts
+++ b/tests/controllers/observability.test.ts
@@ -4,8 +4,8 @@ describe("ObservabilityController", () => {
   const apiToken = "123456";
   const addresses: Addresses = {
     default: "http://localhost:19191/api",
-    data: "http://localhost:19193/api/v1/data",
-    ids: "http://consumer-connector:9194/api/v1/ids",
+    management: "http://localhost:19193/api/v1/data",
+    protocol: "http://consumer-connector:9194/api/v1/ids",
     public: "http://localhost:19291/public",
     control: "http://localhost:19292/control",
   };

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -12,15 +12,15 @@ describe("PublicController", () => {
   const apiToken = "123456";
   const consumer: Addresses = {
     default: "http://localhost:19191/api",
-    data: "http://localhost:19193/api/v1/data",
-    ids: "http://consumer-connector:9194/api/v1/ids",
+    management: "http://localhost:19193/api/v1/data",
+    protocol: "http://consumer-connector:9194/api/v1/ids",
     public: "http://localhost:19291/public",
     control: "http://localhost:19292/control",
   };
   const provider: Addresses = {
     default: "http://localhost:29191/api",
-    data: "http://localhost:29193/api/v1/data",
-    ids: "http://provider-connector:9194/api/v1/ids",
+    management: "http://localhost:29193/api/v1/data",
+    protocol: "http://provider-connector:9194/api/v1/ids",
     public: "http://localhost:29291/public",
     control: "http://localhost:29292/control",
   };
@@ -78,7 +78,7 @@ describe("PublicController", () => {
         {
           assetId,
           "connectorId": "provider",
-          "connectorAddress": `${providerContext.ids}/data`,
+          "connectorAddress": `${providerContext.protocol}/data`,
           "contractId": contractAgreement.id,
           "managedResources": false,
           "dataDestination": { "type": "HttpProxy" },

--- a/tests/edc-client.test.ts
+++ b/tests/edc-client.test.ts
@@ -20,8 +20,8 @@ describe("EdcConnectorClient", () => {
       const apiToken = "123456";
       const addresses: Addresses = {
         default: "http://localhost:19191",
-        data: "http://localhost:19193",
-        ids: "http://localhost:19194",
+        management: "http://localhost:19193",
+        protocol: "http://localhost:19194",
         public: "http://localhost:19291",
         control: "http://localhost:19292",
       };
@@ -33,8 +33,8 @@ describe("EdcConnectorClient", () => {
       expect(context).toBeInstanceOf(EdcConnectorClientContext);
       expect(context.apiToken).toBe(apiToken);
       expect(context.default).toBe(addresses.default);
-      expect(context.data).toBe(addresses.data);
-      expect(context.ids).toBe(addresses.ids);
+      expect(context.management).toBe(addresses.management);
+      expect(context.protocol).toBe(addresses.protocol);
       expect(context.public).toBe(addresses.public);
       expect(context.control).toBe(addresses.control);
     });

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -146,7 +146,7 @@ export async function createContractNegotiation(
 
   // Retrieve catalog and select contract offer
   const catalog = await client.management.requestCatalog(consumerContext, {
-    providerUrl: `${providerContext.ids}/data`,
+    providerUrl: `${providerContext.protocol}/data`,
   });
   const contractOffer = catalog.contractOffers.find((offer) =>
     offer.asset?.id === assetId
@@ -155,7 +155,7 @@ export async function createContractNegotiation(
   // Initiate contract negotiation on the consumer's side
   const createResult = await client.management
     .initiateContractNegotiation(consumerContext, {
-      connectorAddress: `${providerContext.ids}/data`,
+      connectorAddress: `${providerContext.protocol}/data`,
       connectorId: "provider",
       offer: {
         offerId: contractOffer.id as string,


### PR DESCRIPTION
Keeping consistency with EDC Connector's configuration names