### PR TITLE
Bump EDC to 0.1.3

### DIFF
--- a/.github/workflows/publish-test-connector-image.yml
+++ b/.github/workflows/publish-test-connector-image.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  CONNECTOR_TAG: 0.1.2
+  CONNECTOR_TAG: 0.1.3
 
 jobs:
   build-and-push-image:

--- a/.github/workflows/pull-request-testing.yml
+++ b/.github/workflows/pull-request-testing.yml
@@ -9,6 +9,7 @@ on:
       - 'jest.config.ts'
       - 'src/**/*.ts'
       - 'tests/**/*.ts'
+      - 'connector'
 
 env:
   REGISTRY: ghcr.io

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project aims to increase the level of abstraction, bringing the _low-level_
 developers by providing an HTTP Client which is thoroughly tested and fully type-safe.
 
 > Similarly to the **EDC Connector**, this library is at its early stage.
-> It aims to maintain compatibility with the latest version of the _Connector_, currently `0.1.2`.
+> It aims to maintain compatibility with the latest version of the _Connector_, currently `0.1.3`.
 > The compatibility is reflected in the library's versioning.
 
 ## Usage

--- a/connector/build.gradle.kts
+++ b/connector/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 val edcGroupId = "org.eclipse.edc"
-val edcVersion = "0.1.2"
+val edcVersion = "0.1.3"
 
 dependencies {
     implementation("${edcGroupId}:runtime-metamodel:${edcVersion}")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-it-labs/edc-connector-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "EDC Connector HTTP client",
   "private": false,
   "main": "dist/src/index.js",

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -14,6 +14,7 @@ import {
   Dataplane,
   DataplaneInput,
   IdResponse,
+  JsonLdObject,
   PolicyDefinition,
   PolicyDefinitionInput,
   QuerySpec,
@@ -62,7 +63,7 @@ export class ManagementController {
     input: AssetInput,
   ): Promise<IdResponse> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/assets",
         method: "POST",
         apiToken: context.apiToken,
@@ -71,8 +72,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+      .then(body => this.expand(body, () => new IdResponse()));
   }
 
   async deleteAsset(
@@ -131,7 +131,7 @@ export class ManagementController {
     input: PolicyDefinitionInput,
   ): Promise<IdResponse> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/policydefinitions",
         method: "POST",
         apiToken: context.apiToken,
@@ -140,8 +140,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+      .then(body => this.expand(body, () => new IdResponse()));
   }
 
   async deletePolicy(
@@ -163,7 +162,8 @@ export class ManagementController {
       path: `/v2/policydefinitions/${policyId}`,
       method: "GET",
       apiToken: context.apiToken,
-    });
+    })
+    .then(body => this.expand(body, () => new PolicyDefinition()));
   }
 
   async queryAllPolicies(
@@ -171,7 +171,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<PolicyDefinition[]> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/policydefinitions/request",
         method: "POST",
         apiToken: context.apiToken,
@@ -183,12 +183,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        (expanded as Array<any>).map((it) =>
-          Object.assign(new PolicyDefinition(), it),
-        ),
-      );
+      .then(body => this.expandArray(body, () => new PolicyDefinition()));
   }
 
   async createContractDefinition(
@@ -196,7 +191,7 @@ export class ManagementController {
     input: ContractDefinitionInput,
   ): Promise<IdResponse> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/contractdefinitions",
         method: "POST",
         apiToken: context.apiToken,
@@ -205,8 +200,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+      .then(body => this.expand(body, () => new IdResponse()));
   }
 
   async deleteContractDefinition(
@@ -236,7 +230,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<ContractDefinition[]> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/contractdefinitions/request",
         method: "POST",
         apiToken: context.apiToken,
@@ -248,12 +242,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        (expanded as Array<any>).map((it) =>
-          Object.assign(new ContractNegotiation(), it),
-        ),
-      );
+      .then(body => this.expandArray(body, () => new ContractDefinition()));
   }
 
   async requestCatalog(
@@ -261,7 +250,7 @@ export class ManagementController {
     input: CatalogRequest,
   ): Promise<Catalog> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/catalog/request",
         method: "POST",
         apiToken: context.apiToken,
@@ -271,12 +260,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then(async body => {
-        const expanded = await jsonld.expand(body);
-        var catalog = Object.assign(new Catalog(), expanded[0]);
-        catalog._compacted = body;
-        return catalog;
-      });
+      .then(body => this.expand(body, () => new Catalog()));
   }
 
   async initiateContractNegotiation(
@@ -284,7 +268,7 @@ export class ManagementController {
     input: ContractNegotiationRequest,
   ): Promise<IdResponse> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/contractnegotiations",
         method: "POST",
         apiToken: context.apiToken,
@@ -294,8 +278,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+      .then(body => this.expand(body, () => new IdResponse()));
   }
 
   async queryNegotiations(
@@ -313,7 +296,8 @@ export class ManagementController {
               ...query,
               "@context": this.defaultContextValues,
             },
-    });
+    })
+    .then(body => this.expandArray(body, () => new ContractNegotiation()));
   }
 
   async getNegotiation(
@@ -321,15 +305,12 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractNegotiation> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: `/v2/contractnegotiations/${negotiationId}`,
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        Object.assign(new ContractNegotiation(), expanded[0]),
-      );
+      .then(body => this.expand(body, () => new ContractNegotiation()));
   }
 
   async getNegotiationState(
@@ -337,15 +318,12 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractNegotiationState> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: `/v2/contractnegotiations/${negotiationId}/state`,
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        Object.assign(new ContractNegotiationState(), expanded[0]),
-      );
+      .then(body => this.expand(body, () => new ContractNegotiationState()));
   }
 
   async cancelNegotiation(
@@ -375,13 +353,12 @@ export class ManagementController {
     negotiationId: string,
   ): Promise<ContractAgreement> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: `/v2/contractnegotiations/${negotiationId}/agreement`,
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new ContractAgreement(), expanded[0]));
+      .then(body => this.expand(body, () => new ContractAgreement()));
   }
 
   async queryAllAgreements(
@@ -389,7 +366,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<ContractAgreement[]> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/contractagreements/request",
         method: "POST",
         apiToken: context.apiToken,
@@ -401,12 +378,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        (expanded as Array<any>).map((it) =>
-          Object.assign(new ContractAgreement(), it),
-        ),
-      );
+      .then(body => this.expandArray(body, () => new ContractAgreement()));
   }
 
   async getAgreement(
@@ -414,13 +386,12 @@ export class ManagementController {
     agreementId: string,
   ): Promise<ContractAgreement> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: `/v2/contractagreements/${agreementId}`,
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new ContractAgreement(), expanded[0]));
+      .then(body => this.expand(body, () => new ContractAgreement()));
   }
 
   async initiateTransfer(
@@ -428,7 +399,7 @@ export class ManagementController {
     input: TransferProcessInput,
   ): Promise<IdResponse> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/transferprocesses",
         method: "POST",
         apiToken: context.apiToken,
@@ -438,8 +409,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+      .then(body => this.expand(body, () => new IdResponse()));
   }
 
   async queryAllTransferProcesses(
@@ -447,7 +417,7 @@ export class ManagementController {
     query: QuerySpec = {},
   ): Promise<TransferProcess[]> {
     return this.#inner
-      .request<any>(context.management, {
+      .request(context.management, {
         path: "/v2/transferprocesses/request",
         method: "POST",
         apiToken: context.apiToken,
@@ -456,11 +426,22 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) =>
-        (expanded as Array<any>).map((it) =>
-          Object.assign(new TransferProcess(), it),
-        ),
-      );
+      .then(body => this.expandArray(body, () => new TransferProcess()));
+  }
+
+  private async expand<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T> {
+    const expanded = await jsonld.expand(body);
+    var instance = Object.assign(newInstance(), expanded[0]);
+    instance._compacted = body;
+    return instance;
+  }
+
+  private async expandArray<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T[]> {
+    const expanded = await jsonld.expand(body);
+    return (expanded as Array<any>).map((element, index) => {
+      var instance = Object.assign(newInstance(), element);
+      instance._compacted = body[index];
+      return instance;
+    });
   }
 }

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -271,8 +271,12 @@ export class ManagementController {
           ...input,
         },
       })
-      .then((body) => jsonld.expand(body))
-      .then((expanded) => Object.assign(new Catalog(), expanded[0]));
+      .then(async body => {
+        const expanded = await jsonld.expand(body);
+        var catalog = Object.assign(new Catalog(), expanded[0]);
+        catalog._compacted = body;
+        return catalog;
+      });
   }
 
   async initiateContractNegotiation(

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -1,5 +1,7 @@
 import { EdcConnectorClientContext } from "../context";
 import {
+  expand,
+  expandArray,
   AssetResponse,
   AssetInput,
   Catalog,
@@ -14,7 +16,6 @@ import {
   Dataplane,
   DataplaneInput,
   IdResponse,
-  JsonLdObject,
   PolicyDefinition,
   PolicyDefinitionInput,
   QuerySpec,
@@ -23,7 +24,6 @@ import {
   EDC_CONTEXT,
 } from "../entities";
 import { Inner } from "../inner";
-import jsonld from "jsonld";
 
 export class ManagementController {
   #inner: Inner;
@@ -72,7 +72,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then(body => this.expand(body, () => new IdResponse()));
+      .then(body => expand(body, () => new IdResponse()));
   }
 
   async deleteAsset(
@@ -140,7 +140,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then(body => this.expand(body, () => new IdResponse()));
+      .then(body => expand(body, () => new IdResponse()));
   }
 
   async deletePolicy(
@@ -163,7 +163,7 @@ export class ManagementController {
       method: "GET",
       apiToken: context.apiToken,
     })
-    .then(body => this.expand(body, () => new PolicyDefinition()));
+    .then(body => expand(body, () => new PolicyDefinition()));
   }
 
   async queryAllPolicies(
@@ -183,7 +183,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then(body => this.expandArray(body, () => new PolicyDefinition()));
+      .then(body => expandArray(body, () => new PolicyDefinition()));
   }
 
   async createContractDefinition(
@@ -200,7 +200,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then(body => this.expand(body, () => new IdResponse()));
+      .then(body => expand(body, () => new IdResponse()));
   }
 
   async deleteContractDefinition(
@@ -242,7 +242,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then(body => this.expandArray(body, () => new ContractDefinition()));
+      .then(body => expandArray(body, () => new ContractDefinition()));
   }
 
   async requestCatalog(
@@ -260,7 +260,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then(body => this.expand(body, () => new Catalog()));
+      .then(body => expand(body, () => new Catalog()));
   }
 
   async initiateContractNegotiation(
@@ -278,7 +278,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then(body => this.expand(body, () => new IdResponse()));
+      .then(body => expand(body, () => new IdResponse()));
   }
 
   async queryNegotiations(
@@ -297,7 +297,7 @@ export class ManagementController {
               "@context": this.defaultContextValues,
             },
     })
-    .then(body => this.expandArray(body, () => new ContractNegotiation()));
+    .then(body => expandArray(body, () => new ContractNegotiation()));
   }
 
   async getNegotiation(
@@ -310,7 +310,7 @@ export class ManagementController {
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then(body => this.expand(body, () => new ContractNegotiation()));
+      .then(body => expand(body, () => new ContractNegotiation()));
   }
 
   async getNegotiationState(
@@ -323,7 +323,7 @@ export class ManagementController {
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then(body => this.expand(body, () => new ContractNegotiationState()));
+      .then(body => expand(body, () => new ContractNegotiationState()));
   }
 
   async cancelNegotiation(
@@ -358,7 +358,7 @@ export class ManagementController {
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then(body => this.expand(body, () => new ContractAgreement()));
+      .then(body => expand(body, () => new ContractAgreement()));
   }
 
   async queryAllAgreements(
@@ -378,7 +378,7 @@ export class ManagementController {
                 "@context": this.defaultContextValues,
               },
       })
-      .then(body => this.expandArray(body, () => new ContractAgreement()));
+      .then(body => expandArray(body, () => new ContractAgreement()));
   }
 
   async getAgreement(
@@ -391,7 +391,7 @@ export class ManagementController {
         method: "GET",
         apiToken: context.apiToken,
       })
-      .then(body => this.expand(body, () => new ContractAgreement()));
+      .then(body => expand(body, () => new ContractAgreement()));
   }
 
   async initiateTransfer(
@@ -409,7 +409,7 @@ export class ManagementController {
           ...input,
         },
       })
-      .then(body => this.expand(body, () => new IdResponse()));
+      .then(body => expand(body, () => new IdResponse()));
   }
 
   async queryAllTransferProcesses(
@@ -426,22 +426,7 @@ export class ManagementController {
           "@context": this.defaultContextValues,
         },
       })
-      .then(body => this.expandArray(body, () => new TransferProcess()));
+      .then(body => expandArray(body, () => new TransferProcess()));
   }
 
-  private async expand<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T> {
-    const expanded = await jsonld.expand(body);
-    var instance = Object.assign(newInstance(), expanded[0]);
-    instance._compacted = body;
-    return instance;
-  }
-
-  private async expandArray<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T[]> {
-    const expanded = await jsonld.expand(body);
-    return (expanded as Array<any>).map((element, index) => {
-      var instance = Object.assign(newInstance(), element);
-      instance._compacted = body[index];
-      return instance;
-    });
-  }
 }

--- a/src/controllers/public-controller.ts
+++ b/src/controllers/public-controller.ts
@@ -8,7 +8,7 @@ export class PublicController {
     this.#inner = inner;
   }
 
-  async getTranferedData(
+  async getTransferredData(
     context: EdcConnectorClientContext,
     headers: Record<string, string | undefined>,
   ): Promise<Response> {

--- a/src/entities/contract-definition.ts
+++ b/src/entities/contract-definition.ts
@@ -1,9 +1,14 @@
-import { ContextProperties } from "./context";
 import { Criterion } from "./criterion";
+import { JsonLdId } from "./jsonld";
 
-export interface ContractDefinition extends ContextProperties {
-  "@id": string;
-  validity?: number;
+export class ContractDefinition extends JsonLdId {
+  get accessPolicyId(): string {
+    return this.mandatoryValue('edc', 'accessPolicyId');
+  }
+
+  get contractPolicyId(): string {
+    return this.mandatoryValue('edc', 'contractPolicyId');
+  }
 }
 
 export interface ContractDefinitionInput extends Partial<ContractDefinition> {

--- a/src/entities/jsonld.ts
+++ b/src/entities/jsonld.ts
@@ -26,6 +26,11 @@ export class JsonLdObject {
    * look at https://github.com/digitalbazaar/jsonld.js/issues/523
    * Once that issue will be fixed, we can get rid of the _compacted and all
    * its usages.
+   *
+   * Why is this needed: "compacted" is the json-ld representation of the object
+   * we are receiving from the connector, we are keeping it next to the expanded
+   * representation (that is, the content of this JsonLdObject object), getting
+   * the data out of it, if it is valued.
    */
   set _compacted(_compacted: any) {
     this.__compacted = _compacted;
@@ -40,12 +45,12 @@ export class JsonLdObject {
   }
 
   optionalValue<T>(prefix: string, name: string): T | undefined {
-    var namespace = this.getNamespaceUrl(prefix);
     if (this._compacted) {
       const key = `${prefix}:${name}`;
       return this._compacted[key]
     }
 
+    var namespace = this.getNamespaceUrl(prefix);
     return (this[`${namespace}${name}`] as JsonLdValue<T>[])
       ?.map(it => Object.assign(new JsonLdValue(), it))
       ?.at(0)?.value;

--- a/src/entities/jsonld.ts
+++ b/src/entities/jsonld.ts
@@ -10,7 +10,13 @@ export class JsonLdObject {
    * Once that issue will be fixed, we can get rid of the _compacted and all
    * its usages.
    */
-  _compacted: any;
+  set _compacted(_compacted: any) {
+    this.__compacted = _compacted;
+  }
+
+  get _compacted() {
+    return this.__compacted;
+  }
 
   mandatoryValue<T>(prefix: string, name: string): T {
     return this.optionalValue(prefix, name)!;
@@ -54,12 +60,20 @@ export class JsonLdId extends JsonLdObject {
   '@id': string;
 
   get id() {
-    if (this._compacted) {
-      return this._compacted['@id'];
-    } else {
-      return this['@id'];
+    return this['@id'];
+  }
+
+  set _compacted(compacted: any) {
+    this.__compacted = compacted;
+    if (compacted) {
+      this['@id'] = compacted['@id'];
     }
   }
+
+  get _compacted() {
+    return this.__compacted;
+  }
+
 }
 
 export class JsonLdValue<T> {

--- a/src/entities/jsonld.ts
+++ b/src/entities/jsonld.ts
@@ -1,4 +1,21 @@
 import { EDC_CONTEXT } from "./context";
+import jsonld from "jsonld";
+
+export async function expand<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T> {
+  const expanded = await jsonld.expand(body);
+  var instance = Object.assign(newInstance(), expanded[0]);
+  instance._compacted = body;
+  return instance;
+};
+
+export async function expandArray<T extends JsonLdObject>(body: any, newInstance: (() => T)): Promise<T[]> {
+  const expanded = await jsonld.expand(body);
+  return (expanded as Array<any>).map((element, index) => {
+    var instance = Object.assign(newInstance(), element);
+    instance._compacted = body[index];
+    return instance;
+  });
+}
 
 export class JsonLdObject {
 

--- a/src/entities/jsonld.ts
+++ b/src/entities/jsonld.ts
@@ -18,6 +18,11 @@ export class JsonLdObject {
 
   optionalValue<T>(prefix: string, name: string): T | undefined {
     var namespace = this.getNamespaceUrl(prefix);
+    if (this._compacted) {
+      const key = `${prefix}:${name}`;
+      return this._compacted[key]
+    }
+
     return (this[`${namespace}${name}`] as JsonLdValue<T>[])
       ?.map(it => Object.assign(new JsonLdValue(), it))
       ?.at(0)?.value;
@@ -29,7 +34,8 @@ export class JsonLdObject {
       .map((element, index) => {
         const instance = Object.assign(newInstance(), element);
         const jsonLd = instance as any as JsonLdObject;
-        jsonLd._compacted = this._compacted[`${prefix}:${name}`][index]
+        const object = this._compacted[`${prefix}:${name}`]
+        jsonLd._compacted = Array.isArray(object) ? object[index] : object;
         return instance;
       });
   }

--- a/tests/controllers/management.test.ts
+++ b/tests/controllers/management.test.ts
@@ -1083,8 +1083,7 @@ describe("ManagementController", () => {
       expect(contractAgreements.length).toBeGreaterThan(0);
       expect(
         contractAgreements.find(
-          (contractAgreement) =>
-            contractAgreement.id === contractNegotiation.contractAgreementId,
+          agreement => agreement.id === contractNegotiation.contractAgreementId
         ),
       ).toBeTruthy();
     });

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -33,14 +33,14 @@ describe("PublicController", () => {
     await receiverServer.shutdown();
   });
 
-  describe("edcClient.public.getTranferedData", () => {
+  describe("edcClient.public.getTransferredData", () => {
     it("fails to return an object in response", async () => {
       // given
       const edcClient = new EdcConnectorClient();
       const context = edcClient.createContext(apiToken, consumer);
 
       // when
-      const maybeData = edcClient.public.getTranferedData(context, {});
+      const maybeData = edcClient.public.getTransferredData(context, {});
 
       // then
       await expect(maybeData).rejects.toThrowError(
@@ -98,7 +98,7 @@ describe("PublicController", () => {
       const transferProcessResponse = await receiverServer.waitForEvent(idResponse.id);
 
       // when
-      const data = await edcClient.public.getTranferedData(consumerContext, {
+      const data = await edcClient.public.getTransferredData(consumerContext, {
         [transferProcessResponse.authKey]: transferProcessResponse.authCode,
       });
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -124,7 +124,6 @@ export async function createContractNegotiation(
     .flatMap(it => it.offers)
     .find(offer => offer.assetId === assetId)!;
 
-  offer['@id'] = offer._compacted['@id'];
   offer._compacted = undefined;
 
   // Initiate contract negotiation on the consumer's side

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -124,6 +124,9 @@ export async function createContractNegotiation(
     .flatMap(it => it.offers)
     .find(offer => offer.assetId === assetId)!;
 
+  offer['@id'] = offer._compacted['@id'];
+  offer._compacted = undefined;
+
   // Initiate contract negotiation on the consumer's side
   const idResponse = await client.management.initiateContractNegotiation(
     consumerContext,


### PR DESCRIPTION
## Description
Upgrade EDC to 0.1.3

## Approach
I used a workaround to deal with the jsonld.js library bug:
when getting the entities out of the connector, after expansion, I also added a `_compacted` field that will contain the compacted entity, where the data can be get from.
The only nit is that it's needed to set its value to undefined before sending the entity to the connector eventually (this is needed on a negotiation's initialization for example).
I didn't found a way to set it as a "ghost" field (in java there is a "transient" keyword that does the job) so that it can be excluded from serialization, if anyone has any tip, it would be really appreciated.

Closes #43
