### PR TITLE
feat: support asset data address update

### DIFF
--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -20,6 +20,7 @@ import {
   TransferProcess,
   TransferProcessInput,
   EDC_CONTEXT,
+  AssetProperties,
 } from "../entities";
 import { Inner } from "../inner";
 import jsonld from "jsonld";
@@ -73,6 +74,21 @@ export class ManagementController {
       })
       .then((body) => jsonld.expand(body))
       .then((expanded) => Object.assign(new IdResponse(), expanded[0]));
+  }
+
+  async updateAsset(
+    context: EdcConnectorClientContext,
+    input: AssetProperties,
+  ): Promise<void> {
+    return this.#inner.request(context.management, {
+      path: "/v2/assets",
+      method: "PUT",
+      apiToken: context.apiToken,
+      body: {
+        ...input,
+        "@context": this.defaultContextValues,
+      },
+    });
   }
 
   async deleteAsset(

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -108,6 +108,22 @@ export class ManagementController {
     });
   }
 
+  async updateAssetDataAddress(
+    context: EdcConnectorClientContext,
+    assetId: string,
+    input: DataAddressProperties,
+  ): Promise<void> {
+    return this.#inner.request(context.management, {
+      path: `/v2/assets/${assetId}/dataaddress`,
+      method: "PUT",
+      apiToken: context.apiToken,
+      body: {
+        ...input,
+        "@context": this.defaultContextValues,
+      },
+    });
+  }
+
   async queryAllAssets(
     context: EdcConnectorClientContext,
     query: QuerySpec = {},
@@ -447,10 +463,13 @@ export class ManagementController {
         path: "/v2/transferprocesses/request",
         method: "POST",
         apiToken: context.apiToken,
-        body: Object.keys(query).length === 0 ? null : {
-          ...query,
-          "@context": this.defaultContextValues,
-        },
+        body:
+          Object.keys(query).length === 0
+            ? null
+            : {
+                ...query,
+                "@context": this.defaultContextValues,
+              },
       })
       .then((body) => jsonld.expand(body))
       .then((expanded) =>

--- a/src/entities/asset.ts
+++ b/src/entities/asset.ts
@@ -8,7 +8,7 @@ export interface Asset {
   "@id": string;
 }
 
-interface AssetProperties {
+export interface AssetProperties {
   [key: string]: string | undefined | any;
   name?: string;
   description?: string;


### PR DESCRIPTION
## Description
This PR aims at adding support for sending a`PUT` request on **assets** and **data addresses** resources, to update them. 

### How to test it
all tests should be passing

---
