### PR TITLE
feat: upgrade edc to 0.2.0

### DIFF
--- a/.github/workflows/pull-request-testing.yml
+++ b/.github/workflows/pull-request-testing.yml
@@ -2,14 +2,6 @@ name: Pull request testing
 
 on:
   push:
-    branches-ignore:
-      - main
-    paths:
-      - '.github/workflows/pull-request-testing.yml'
-      - 'jest.config.ts'
-      - 'src/**/*.ts'
-      - 'tests/**/*.ts'
-      - 'connector'
 
 env:
   REGISTRY: ghcr.io

--- a/connector/build.gradle.kts
+++ b/connector/build.gradle.kts
@@ -9,7 +9,7 @@ repositories {
 }
 
 val edcGroupId = "org.eclipse.edc"
-val edcVersion = "0.1.3"
+val edcVersion = "0.2.0"
 
 dependencies {
     implementation("${edcGroupId}:runtime-metamodel:${edcVersion}")

--- a/src/controllers/management-controller.ts
+++ b/src/controllers/management-controller.ts
@@ -41,10 +41,13 @@ export class ManagementController {
     input: DataplaneInput,
   ): Promise<void> {
     return this.#inner.request(context.management, {
-      path: "/instances",
+      path: "/v2/dataplanes",
       method: "POST",
       apiToken: context.apiToken,
-      body: input,
+      body: {
+        ...input,
+        "@context": this.defaultContextValues,
+      },
     });
   }
 
@@ -52,10 +55,11 @@ export class ManagementController {
     context: EdcConnectorClientContext,
   ): Promise<Dataplane[]> {
     return this.#inner.request(context.management, {
-      path: "/instances",
+      path: "/v2/dataplanes",
       method: "GET",
       apiToken: context.apiToken,
-    });
+    })
+    .then(body => expandArray(body, () => new Dataplane()));
   }
 
   async createAsset(

--- a/src/entities/dataplane.ts
+++ b/src/entities/dataplane.ts
@@ -1,13 +1,25 @@
-export interface Dataplane {
-  id: string;
-  url: string;
-  lastActive: number;
-  turnCount: number;
-  allowedSourceTypes: string[];
-  allowedDestTypes: string[];
-  properties: {
-    publicApiUrl: string;
-  };
+import { JsonLdId, JsonLdObject, JsonLdValue } from "./jsonld";
+
+export class Dataplane extends JsonLdId {
+
+  get url(): string {
+    return this.mandatoryValue('edc', 'url');
+  }
+
+  get allowedSourceTypes(): String[] {
+    return this.arrayOf(() => new JsonLdValue<string>(), 'edc', 'allowedSourceTypes')
+      .map(it => it.value);
+  }
+
+  get allowedDestTypes(): String[] {
+    return this.arrayOf(() => new JsonLdValue<string>(), 'edc', 'allowedDestTypes')
+      .map(it => it.value);
+  }
+
+  get properties(): JsonLdObject {
+    return this.mandatoryValue('edc', 'properties');
+  }
+
 }
 
 export type DataplaneInput = Omit<Dataplane, "lastActive" | "turnCount">;

--- a/src/entities/jsonld.ts
+++ b/src/entities/jsonld.ts
@@ -85,6 +85,10 @@ export class JsonLdId extends JsonLdObject {
     return this['@id'];
   }
 
+  set id(id: string) {
+    this['@id'] = id;
+  }
+
   set _compacted(compacted: any) {
     this.__compacted = compacted;
     if (compacted) {

--- a/tests/controllers/management.test.ts
+++ b/tests/controllers/management.test.ts
@@ -1224,10 +1224,8 @@ describe("ManagementController", () => {
 
   describe("edcClient.management.listDataplanes", () => {
     it("succesfully list available dataplanes", async () => {
-      // given
       const context = edcClient.createContext(apiToken, consumer);
-      const dataplaneInput = {
-        id: "consumer-dataplane",
+      const input = {
         url: "http://consumer-connector:9192/control/transfer",
         allowedSourceTypes: ["HttpData"],
         allowedDestTypes: ["HttpProxy", "HttpData"],
@@ -1235,28 +1233,20 @@ describe("ManagementController", () => {
           publicApiUrl: "http://consumer-connector:9291/public/",
         },
       };
-      await edcClient.management.registerDataplane(context, dataplaneInput);
+      await edcClient.management.registerDataplane(context, input);
 
-      // when
       const dataplanes = await edcClient.management.listDataplanes(context);
 
-      // then
       expect(dataplanes.length).toBeGreaterThan(0);
       dataplanes.forEach((dataplane) => {
-        expect(dataplane).toHaveProperty("id", dataplaneInput.id);
-        expect(dataplane).toHaveProperty("url", dataplaneInput.url);
-        expect(dataplane).toHaveProperty(
-          "allowedDestTypes",
-          dataplaneInput.allowedDestTypes,
-        );
-        expect(dataplane).toHaveProperty(
-          "allowedSourceTypes",
-          dataplaneInput.allowedSourceTypes,
-        );
-        expect(dataplane).toHaveProperty(
-          "properties",
-          dataplaneInput.properties,
-        );
+        expect(dataplane).toHaveProperty("id");
+        expect(dataplane).toHaveProperty("url", input.url);
+        expect(dataplane)
+          .toHaveProperty("allowedDestTypes", input.allowedDestTypes);
+        expect(dataplane)
+          .toHaveProperty("allowedSourceTypes", input.allowedSourceTypes);
+        expect(dataplane.properties)
+        .toHaveProperty("edc:publicApiUrl", "http://consumer-connector:9291/public/");
       });
     });
   });


### PR DESCRIPTION
## Description
Update EDC to 0.2.0
- switch the old dataplanes endpoint to the `/v2` one

## Further Notes
- I ensured that the "test" CI step runs after every push, no need for exclusions or inclusion: every commit has to pass the CI
- I did not update the version in package.json because it would be nice to have other features before going with the release (e.g. /v3/assets)

Closes #47 