### PR TITLE
feat: make context optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const client = new EdcConnectorClient.Builder()
 
 At this point the calls can be made against the specified connector:
 ```ts
-const result = await client.management.createAsset({
+const result = await client.management.assets.create({
   asset: {
     properties: {
       "asset:prop:id": "a-http-asset-id",
@@ -100,7 +100,7 @@ const context = client.createContext("123456", {
 
 And the context can be passed to every call as latest argument:
 ```ts
-const result = await client.management.createAsset(context, {
+const result = await client.management.assets.create(context, {
   asset: {
     properties: {
       "asset:prop:id": "a-http-asset-id",

--- a/README.md
+++ b/README.md
@@ -38,28 +38,24 @@ yarn add @think-it-labs/edc-connector-client
 
 Once installed, clients can be instanciated by construcing a `EdcConnectorClient`.
 
+### With internal context
+
+The standard way of using the client would be associating it with a connector,
+for doing that it can be instantiated through the `EdcConnectorClientBuilder`
+
 ```ts
-import { EdcConnectorClient } from "@think-it-labs/edc-connector-client"
+import { EdcConnectorClientBuilder } from "@think-it-labs/edc-connector-client"
 
-const edcConnectorClient = new EdcConnectorClient();
-
+const client = new EdcConnectorClientBuilder()
+  .apiToken("123456")
+  .managementUrl("https://edc.think-it.io/management")
+  .publicUrl("https://edc.think-it.io/public")
+  .build();
 ```
 
-The `EdcConnectorClient` is connector-agnostic; hence it doesn't know nor store
-connectors' token and addresses. Instead, these are passed to each method through a context
-object, representing a unique connector.
-
+At this point the calls can be made against the specified connector:
 ```ts
-
-const context = edcConnectorClient.createContext("123456", {
-  default: "https://edc.think-it.io/api",
-  management: "https://edc.think-it.io/management",
-  protocol: "https://edc.think-it.io/protocol",
-  public: "https://edc.think-it.io/public",
-  control: "https://edc.think-it.io/control",
-});
-
-const result = await edcConnectorClient.management.createAsset(context, {
+const result = await client.management.createAsset({
   asset: {
     properties: {
       "asset:prop:id": "a-http-asset-id",
@@ -77,8 +73,54 @@ const result = await edcConnectorClient.management.createAsset(context, {
     },
   },
 });
-
 ```
+
+### Without internal context
+
+A single connector instance can be used to call multiple connectors, just creating
+different contexts and passing them to the specific call.
+
+The connector can be instantiated directly without the builder:
+```ts
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client"
+
+const client = new EdcConnectorClient();
+```
+
+Context objects can be created with a `createContext` call:
+```ts
+const context = client.createContext("123456", {
+  default: "https://edc.think-it.io/api",
+  management: "https://edc.think-it.io/management",
+  protocol: "https://edc.think-it.io/protocol",
+  public: "https://edc.think-it.io/public",
+  control: "https://edc.think-it.io/control",
+});
+```
+
+And the context can be passed to every call as latest argument:
+```ts
+const result = await client.management.createAsset(context, {
+  asset: {
+    properties: {
+      "asset:prop:id": "a-http-asset-id",
+      "asset:prop:name": "A HTTP asset",
+    }
+  },
+  dataAddress: {
+    properties: {
+      name: "An HTTP address",
+      baseUrl: "https://example.com/",
+      type: "HttpData",
+      path: "/some-data",
+      contentType: "application/json",
+      method: "GET",
+    },
+  },
+});
+```
+
+## Error handling
 
 All API methods are _type, and error-safe_, which means arguments are fully typed
 with [TypeScript](https://www.typescriptlang.org/), and thrown errors are always
@@ -112,15 +154,12 @@ try {
 
 ```
 
-> **Note** if you encounter an `Unknown` error you should report this behaviour
-> along steps to reproduce it. `Unknown` behaviours are unwanted and must be fixed asap.
+> **Note** if you encounter an `Unknown` error you should report this behavior
+> along steps to reproduce it. `Unknown` behaviors are unwanted and must be fixed asap.
 
 ## Development
 
-The development of this library is following a TDD approach. At the moment it
-doesn't cover all EDC Connector capabilities, but aims to do so.
-
-`docker-compose` is used to run the development environment. It runs two
+`docker compose` is used to run the development environment. It runs two
 connectors with capabilities described in the
 [gradle configuration](connector/build.gradle.kts) file.
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Once installed, clients can be instanciated by construcing a `EdcConnectorClient
 ### With internal context
 
 The standard way of using the client would be associating it with a connector,
-for doing that it can be instantiated through the `EdcConnectorClientBuilder`
+for doing that it can be instantiated through the `EdcConnectorClient.Builder`
 
 ```ts
-import { EdcConnectorClientBuilder } from "@think-it-labs/edc-connector-client"
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client"
 
-const client = new EdcConnectorClientBuilder()
+const client = new EdcConnectorClient.Builder()
   .apiToken("123456")
   .managementUrl("https://edc.think-it.io/management")
   .publicUrl("https://edc.think-it.io/public")

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ export class EdcConnectorClient {
 
   apiToken: string | undefined;
   addresses: Addresses = {};
-  inner = new Inner();
+  private inner = new Inner();
 
   constructor() {
 
@@ -45,7 +45,7 @@ export class EdcConnectorClient {
 }
 
 export class EdcConnectorClientBuilder {
-  instance = new EdcConnectorClient();
+  private instance = new EdcConnectorClient();
 
   apiToken(apiToken: string): EdcConnectorClientBuilder {
     this.instance.apiToken = apiToken

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,16 +7,28 @@ import { version } from "../package.json";
 import { ManagementController } from "./facades/management";
 
 export class EdcConnectorClient {
-  readonly management: ManagementController;
-  readonly observability: ObservabilityController;
-  readonly public: PublicController;
+
+  apiToken: string | undefined;
+  addresses: Addresses = {};
+  inner = new Inner();
 
   constructor() {
-    const inner = new Inner();
 
-    this.management = new ManagementController(inner);
-    this.observability = new ObservabilityController(inner);
-    this.public = new PublicController(inner);
+  }
+
+  get management() {
+    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
+    return new ManagementController(this.inner, context);
+  }
+
+  get observability() {
+    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
+    return new ObservabilityController(this.inner, context);
+  }
+
+  get public() {
+    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
+    return new PublicController(this.inner, context);
   }
 
   createContext(
@@ -28,5 +40,44 @@ export class EdcConnectorClient {
 
   static version(): string {
     return version;
+  }
+
+}
+
+export class EdcConnectorClientBuilder {
+  instance = new EdcConnectorClient();
+
+  apiToken(apiToken: string): EdcConnectorClientBuilder {
+    this.instance.apiToken = apiToken
+    return this;
+  }
+
+  managementUrl(managementUrl: string): EdcConnectorClientBuilder {
+    this.instance.addresses.management = managementUrl;
+    return this;
+  }
+
+  defaultUrl(defaultUrl: string): EdcConnectorClientBuilder {
+    this.instance.addresses.default = defaultUrl;
+    return this;
+  }
+
+  protocolUrl(protocolUrl: string): EdcConnectorClientBuilder {
+    this.instance.addresses.protocol = protocolUrl;
+    return this;
+  }
+
+  publicUrl(publicUrl: string): EdcConnectorClientBuilder {
+    this.instance.addresses.public = publicUrl;
+    return this;
+  }
+
+  controlUrl(controlUrl: string): EdcConnectorClientBuilder {
+    this.instance.addresses.control = controlUrl;
+    return this;
+  }
+
+  build(): EdcConnectorClient {
+    return this.instance;
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,27 +8,31 @@ import { ManagementController } from "./facades/management";
 
 export class EdcConnectorClient {
 
-  apiToken: string | undefined;
-  addresses: Addresses = {};
-  private inner = new Inner();
+  #apiToken: string | undefined;
+  #addresses: Addresses = {};
+  #inner = new Inner();
 
   constructor() {
 
   }
 
   get management() {
-    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
-    return new ManagementController(this.inner, context);
+    const context = new EdcConnectorClientContext(this.#apiToken, this.#addresses);
+    return new ManagementController(this.#inner, context);
   }
 
   get observability() {
-    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
-    return new ObservabilityController(this.inner, context);
+    const context = new EdcConnectorClientContext(this.#apiToken, this.#addresses);
+    return new ObservabilityController(this.#inner, context);
   }
 
   get public() {
-    const context = new EdcConnectorClientContext(this.apiToken, this.addresses);
-    return new PublicController(this.inner, context);
+    const context = new EdcConnectorClientContext(this.#apiToken, this.#addresses);
+    return new PublicController(this.#inner, context);
+  }
+
+  get addresses() {
+    return this.#addresses;
   }
 
   createContext(
@@ -42,42 +46,42 @@ export class EdcConnectorClient {
     return version;
   }
 
-}
+  static Builder = class Builder {
+    #instance = new EdcConnectorClient();
 
-export class EdcConnectorClientBuilder {
-  private instance = new EdcConnectorClient();
+    apiToken(apiToken: string): Builder {
+      this.#instance.#apiToken = apiToken
+      return this;
+    }
 
-  apiToken(apiToken: string): EdcConnectorClientBuilder {
-    this.instance.apiToken = apiToken
-    return this;
+    managementUrl(managementUrl: string): Builder {
+      this.#instance.#addresses.management = managementUrl;
+      return this;
+    }
+
+    defaultUrl(defaultUrl: string): Builder {
+      this.#instance.#addresses.default = defaultUrl;
+      return this;
+    }
+
+    protocolUrl(protocolUrl: string): Builder {
+      this.#instance.#addresses.protocol = protocolUrl;
+      return this;
+    }
+
+    publicUrl(publicUrl: string): Builder {
+      this.#instance.#addresses.public = publicUrl;
+      return this;
+    }
+
+    controlUrl(controlUrl: string): Builder {
+      this.#instance.#addresses.control = controlUrl;
+      return this;
+    }
+
+    build(): EdcConnectorClient {
+      return this.#instance;
+    }
   }
 
-  managementUrl(managementUrl: string): EdcConnectorClientBuilder {
-    this.instance.addresses.management = managementUrl;
-    return this;
-  }
-
-  defaultUrl(defaultUrl: string): EdcConnectorClientBuilder {
-    this.instance.addresses.default = defaultUrl;
-    return this;
-  }
-
-  protocolUrl(protocolUrl: string): EdcConnectorClientBuilder {
-    this.instance.addresses.protocol = protocolUrl;
-    return this;
-  }
-
-  publicUrl(publicUrl: string): EdcConnectorClientBuilder {
-    this.instance.addresses.public = publicUrl;
-    return this;
-  }
-
-  controlUrl(controlUrl: string): EdcConnectorClientBuilder {
-    this.instance.addresses.control = controlUrl;
-    return this;
-  }
-
-  build(): EdcConnectorClient {
-    return this.instance;
-  }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,26 +10,34 @@ export class EdcConnectorClientContext implements Addresses {
   }
 
   get default(): string {
-    return this.#addresses.default!;
+    return this.getOrError(this.#addresses.default, 'default address');
   }
 
   get protocol(): string {
-    return this.#addresses.protocol!;
+    return this.getOrError(this.#addresses.protocol, 'protocol address');
   }
 
   get management(): string {
-    return this.#addresses.management!;
+    return this.getOrError(this.#addresses.management, 'management address');
   }
 
   get control(): string {
-    return this.#addresses.control!;
+    return this.getOrError(this.#addresses.control, 'control address');
   }
 
   get public(): string {
-    return this.#addresses.public!;
+    return this.getOrError(this.#addresses.public, 'public address');
   }
 
   get apiToken(): string | undefined {
     return this.#apiToken;
+  }
+
+  private getOrError(property: string | undefined, propertyName: string) : string {
+    if (property) {
+      return property!;
+    } else {
+      throw new Error(`'${propertyName}' has not been set on the client`)
+    }
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,35 +1,35 @@
 import { Addresses } from "./entities";
 
 export class EdcConnectorClientContext implements Addresses {
-  #apiToken: string;
+  #apiToken: string | undefined;
   #addresses: Addresses;
 
-  constructor(apiToken: string, addresses: Addresses) {
+  constructor(apiToken: string | undefined, addresses: Addresses) {
     this.#apiToken = apiToken;
     this.#addresses = addresses;
   }
 
   get default(): string {
-    return this.#addresses.default;
+    return this.#addresses.default!;
   }
 
   get protocol(): string {
-    return this.#addresses.protocol;
+    return this.#addresses.protocol!;
   }
 
   get management(): string {
-    return this.#addresses.management;
+    return this.#addresses.management!;
   }
 
   get control(): string {
-    return this.#addresses.control;
+    return this.#addresses.control!;
   }
 
   get public(): string {
-    return this.#addresses.public;
+    return this.#addresses.public!;
   }
 
-  get apiToken(): string {
+  get apiToken(): string | undefined {
     return this.#apiToken;
   }
 }

--- a/src/controllers/management-controllers/asset-controller.ts
+++ b/src/controllers/management-controllers/asset-controller.ts
@@ -11,23 +11,27 @@ import { Inner } from "../../inner";
 
 export class AssetController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async create(
-    context: EdcConnectorClientContext,
     input: AssetInput,
+    context?: EdcConnectorClientContext,
   ): Promise<IdResponse> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v3/assets",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           ...input,
           "@context": this.defaultContextValues,
@@ -37,35 +41,41 @@ export class AssetController {
   }
 
   async delete(
-    context: EdcConnectorClientContext,
     assetId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v3/assets/${assetId}`,
       method: "DELETE",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async get(
-    context: EdcConnectorClientContext,
     assetId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<AssetResponse> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v3/assets/${assetId}`,
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async update(
-    context: EdcConnectorClientContext,
     input: AssetInput,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: "/v3/assets",
       method: "PUT",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
       body: {
         ...input,
         "@context": this.defaultContextValues,
@@ -74,13 +84,15 @@ export class AssetController {
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<AssetResponse[]> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: "/v3/assets/request",
       method: "POST",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
       body:
         Object.keys(query).length === 0
           ? null

--- a/src/controllers/management-controllers/catalog-controller.ts
+++ b/src/controllers/management-controllers/catalog-controller.ts
@@ -4,24 +4,28 @@ import { Inner } from "../../inner";
 
 export class CatalogController {
   #inner: Inner;
+  #context: EdcConnectorClientContext | undefined;
   protocol: String = "dataspace-protocol-http";
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
-  async queryAll(
-    context: EdcConnectorClientContext,
+  async request(
     input: CatalogRequest,
+    context?: EdcConnectorClientContext,
   ): Promise<Catalog> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/catalog/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           "@context": this.defaultContextValues,
           protocol: this.protocol,
@@ -29,5 +33,15 @@ export class CatalogController {
         },
       })
       .then((body) => expand(body, () => new Catalog()));
+  }
+
+  /**
+   * @deprecated please use `request` instead
+   */
+  async queryAll(
+    input: CatalogRequest,
+    context?: EdcConnectorClientContext,
+  ): Promise<Catalog> {
+    return this.request(input, context);
   }
 }

--- a/src/controllers/management-controllers/contract-agreement-controller.ts
+++ b/src/controllers/management-controllers/contract-agreement-controller.ts
@@ -10,23 +10,27 @@ import { Inner } from "../../inner";
 
 export class ContractAgreementController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<ContractAgreement[]> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/contractagreements/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body:
           Object.keys(query).length === 0
             ? null
@@ -39,14 +43,16 @@ export class ContractAgreementController {
   }
 
   async get(
-    context: EdcConnectorClientContext,
     agreementId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<ContractAgreement> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: `/v2/contractagreements/${agreementId}`,
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expand(body, () => new ContractAgreement()));
   }

--- a/src/controllers/management-controllers/contract-defintion-controller.ts
+++ b/src/controllers/management-controllers/contract-defintion-controller.ts
@@ -12,23 +12,27 @@ import { Inner } from "../../inner";
 
 export class ContractDefinitionController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async create(
-    context: EdcConnectorClientContext,
     input: ContractDefinitionInput,
+    context?: EdcConnectorClientContext,
   ): Promise<IdResponse> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/contractdefinitions",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           ...input,
           "@context": this.defaultContextValues,
@@ -38,36 +42,42 @@ export class ContractDefinitionController {
   }
 
   async delete(
-    context: EdcConnectorClientContext,
     contractDefinitionId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v2/contractdefinitions/${contractDefinitionId}`,
       method: "DELETE",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async get(
-    context: EdcConnectorClientContext,
     contractDefinitionId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<ContractDefinition> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v2/contractdefinitions/${contractDefinitionId}`,
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<ContractDefinition[]> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/contractdefinitions/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body:
           Object.keys(query).length === 0
             ? null
@@ -80,13 +90,15 @@ export class ContractDefinitionController {
   }
 
   async update(
-    context: EdcConnectorClientContext,
     input: ContractDefinitionInput,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: "/v2/contractdefinitions",
       method: "PUT",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
       body: {
         ...input,
         "@context": this.defaultContextValues,

--- a/src/controllers/management-controllers/contract-negotiation-controller.ts
+++ b/src/controllers/management-controllers/contract-negotiation-controller.ts
@@ -14,24 +14,28 @@ import { Inner } from "../../inner";
 
 export class ContractNegotiationController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   protocol: String = "dataspace-protocol-http";
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async initiate(
-    context: EdcConnectorClientContext,
     input: ContractNegotiationRequest,
+    context?: EdcConnectorClientContext,
   ): Promise<IdResponse> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/contractnegotiations",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           protocol: this.protocol,
           "@context": this.defaultContextValues,
@@ -42,14 +46,16 @@ export class ContractNegotiationController {
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<ContractNegotiation[]> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/contractnegotiations/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body:
           Object.keys(query).length === 0
             ? null
@@ -62,40 +68,46 @@ export class ContractNegotiationController {
   }
 
   async get(
-    context: EdcConnectorClientContext,
     negotiationId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<ContractNegotiation> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: `/v2/contractnegotiations/${negotiationId}`,
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expand(body, () => new ContractNegotiation()));
   }
 
   async getState(
-    context: EdcConnectorClientContext,
     negotiationId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<ContractNegotiationState> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: `/v2/contractnegotiations/${negotiationId}/state`,
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expand(body, () => new ContractNegotiationState()));
   }
 
   async terminate(
-    context: EdcConnectorClientContext,
     negotiationId: string,
     reason: string,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v2/contractnegotiations/${negotiationId}/terminate`,
       method: "POST",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
       body: {
         reason: reason,
         "@id": negotiationId,
@@ -105,14 +117,16 @@ export class ContractNegotiationController {
   }
 
   async getAgreement(
-    context: EdcConnectorClientContext,
     negotiationId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<ContractAgreement> {
+    const actualContext = context || this.#context!;
+    
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: `/v2/contractnegotiations/${negotiationId}/agreement`,
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expand(body, () => new ContractAgreement()));
   }

--- a/src/controllers/management-controllers/dataplane-controller.ts
+++ b/src/controllers/management-controllers/dataplane-controller.ts
@@ -9,22 +9,26 @@ import { Inner } from "../../inner";
 
 export class DataplaneController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async register(
-    context: EdcConnectorClientContext,
     input: DataplaneInput,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: "/v2/dataplanes",
       method: "POST",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
       body: {
         ...input,
         "@context": this.defaultContextValues,
@@ -32,12 +36,14 @@ export class DataplaneController {
     });
   }
 
-  async list(context: EdcConnectorClientContext): Promise<Dataplane[]> {
+  async list(context?: EdcConnectorClientContext): Promise<Dataplane[]> {
+    const actualContext = context || this.#context!;
+    
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/dataplanes",
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expandArray(body, () => new Dataplane()));
   }

--- a/src/controllers/management-controllers/policy-defintion-controller.ts
+++ b/src/controllers/management-controllers/policy-defintion-controller.ts
@@ -12,23 +12,27 @@ import { Inner } from "../../inner";
 
 export class PolicyDefinitionController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async create(
-    context: EdcConnectorClientContext,
     input: PolicyDefinitionInput,
+    context?: EdcConnectorClientContext,
   ): Promise<IdResponse> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/policydefinitions",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           ...input,
           "@context": this.defaultContextValues,
@@ -38,38 +42,44 @@ export class PolicyDefinitionController {
   }
 
   async delete(
-    context: EdcConnectorClientContext,
     policyId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<void> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.management, {
       path: `/v2/policydefinitions/${policyId}`,
       method: "DELETE",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async get(
-    context: EdcConnectorClientContext,
     policyId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<PolicyDefinition> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: `/v2/policydefinitions/${policyId}`,
         method: "GET",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
       })
       .then((body) => expand(body, () => new PolicyDefinition()));
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<PolicyDefinition[]> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/policydefinitions/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body:
           Object.keys(query).length === 0
             ? null

--- a/src/controllers/management-controllers/transfer-process-controller.ts
+++ b/src/controllers/management-controllers/transfer-process-controller.ts
@@ -13,24 +13,28 @@ import { Inner } from "../../inner";
 
 export class TransferProcessController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
   protocol: String = "dataspace-protocol-http";
   defaultContextValues = {
     edc: EDC_CONTEXT,
   };
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async initiate(
-    context: EdcConnectorClientContext,
     input: TransferProcessInput,
+    context?: EdcConnectorClientContext,
   ): Promise<IdResponse> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/transferprocesses",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body: {
           "@context": this.defaultContextValues,
           protocol: this.protocol,
@@ -41,14 +45,16 @@ export class TransferProcessController {
   }
 
   async queryAll(
-    context: EdcConnectorClientContext,
     query: QuerySpec = {},
+    context?: EdcConnectorClientContext,
   ): Promise<TransferProcess[]> {
+    const actualContext = context || this.#context!;
+
     return this.#inner
-      .request(context.management, {
+      .request(actualContext.management, {
         path: "/v2/transferprocesses/request",
         method: "POST",
-        apiToken: context.apiToken,
+        apiToken: actualContext.apiToken,
         body:
           Object.keys(query).length === 0
             ? null
@@ -61,13 +67,15 @@ export class TransferProcessController {
   }
 
   async getState(
-    context: EdcConnectorClientContext,
     transferProcessId: string,
+    context?: EdcConnectorClientContext,
   ): Promise<TransferProcessState> {
-    return this.#inner.request(context.management, {
+    const actualContext = context || this.#context!;
+    
+    return this.#inner.request(actualContext.management, {
       path: `/v2/transferprocesses/${transferProcessId}/state`,
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 }

--- a/src/controllers/observability-controller.ts
+++ b/src/controllers/observability-controller.ts
@@ -4,46 +4,56 @@ import { Inner } from "../inner";
 
 export class ObservabilityController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
-  async checkHealth(context: EdcConnectorClientContext): Promise<HealthStatus> {
-    return this.#inner.request(context.default, {
+  async checkHealth(context?: EdcConnectorClientContext): Promise<HealthStatus> {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.default, {
       path: "/check/health",
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async checkLiveness(
-    context: EdcConnectorClientContext,
+    context?: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
-    return this.#inner.request(context.default, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.default, {
       path: "/check/liveness",
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async checkReadiness(
-    context: EdcConnectorClientContext,
+    context?: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
-    return this.#inner.request(context.default, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.request(actualContext.default, {
       path: "/check/readiness",
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 
   async checkStartup(
-    context: EdcConnectorClientContext,
+    context?: EdcConnectorClientContext,
   ): Promise<HealthStatus> {
-    return this.#inner.request(context.default, {
+    const actualContext = context || this.#context!;
+    
+    return this.#inner.request(actualContext.default, {
       path: "/check/startup",
       method: "GET",
-      apiToken: context.apiToken,
+      apiToken: actualContext.apiToken,
     });
   }
 }

--- a/src/controllers/public-controller.ts
+++ b/src/controllers/public-controller.ts
@@ -3,16 +3,20 @@ import { Inner } from "../inner";
 
 export class PublicController {
   #inner: Inner;
+  #context?: EdcConnectorClientContext;
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   async getTransferredData(
-    context: EdcConnectorClientContext,
     headers: Record<string, string | undefined>,
+    context?: EdcConnectorClientContext,
   ): Promise<Response> {
-    return this.#inner.stream(context.public, {
+    const actualContext = context || this.#context!;
+
+    return this.#inner.stream(actualContext.public, {
       path: "/",
       method: "GET",
       headers,

--- a/src/entities/addresses.ts
+++ b/src/entities/addresses.ts
@@ -1,7 +1,7 @@
 export interface Addresses {
-  default: string;
-  management: string;
-  protocol: string;
-  public: string;
-  control: string;
+  default?: string;
+  management?: string;
+  protocol?: string;
+  public?: string;
+  control?: string;
 }

--- a/src/facades/management.ts
+++ b/src/facades/management.ts
@@ -1,4 +1,5 @@
 import { Inner } from "../inner";
+import { EdcConnectorClientContext } from "../context";
 import {
   AssetController,
   CatalogController,
@@ -12,33 +13,35 @@ import {
 
 export class ManagementController {
   #inner: Inner;
+  #context: EdcConnectorClientContext | undefined;
 
-  constructor(inner: Inner) {
+  constructor(inner: Inner, context?: EdcConnectorClientContext) {
     this.#inner = inner;
+    this.#context = context;
   }
 
   get assets() {
-    return new AssetController(this.#inner);
+    return new AssetController(this.#inner, this.#context);
   }
   get catalog() {
-    return new CatalogController(this.#inner);
+    return new CatalogController(this.#inner, this.#context);
   }
   get contractAgreements() {
-    return new ContractAgreementController(this.#inner);
+    return new ContractAgreementController(this.#inner, this.#context);
   }
   get contractDefinitions() {
-    return new ContractDefinitionController(this.#inner);
+    return new ContractDefinitionController(this.#inner, this.#context);
   }
   get contractNegotiations() {
-    return new ContractNegotiationController(this.#inner);
+    return new ContractNegotiationController(this.#inner, this.#context);
   }
   get dataplanes() {
-    return new DataplaneController(this.#inner);
+    return new DataplaneController(this.#inner, this.#context);
   }
   get policyDefinitions() {
-    return new PolicyDefinitionController(this.#inner);
+    return new PolicyDefinitionController(this.#inner, this.#context);
   }
   get transferProcesses() {
-    return new TransferProcessController(this.#inner);
+    return new TransferProcessController(this.#inner, this.#context);
   }
 }

--- a/tests/controllers/management-tests/assets.test.ts
+++ b/tests/controllers/management-tests/assets.test.ts
@@ -2,7 +2,7 @@ import * as crypto from "node:crypto";
 import {
   AssetInput,
   EDC_NAMESPACE,
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
 } from "../../../src";
 import {
   EdcConnectorClientError,
@@ -10,7 +10,7 @@ import {
 } from "../../../src/error";
 
 describe("AssetController", () => {
-  const edcClient = new EdcConnectorClientBuilder()
+  const edcClient = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .build();

--- a/tests/controllers/management-tests/catalog.test.ts
+++ b/tests/controllers/management-tests/catalog.test.ts
@@ -2,20 +2,20 @@ import * as crypto from "node:crypto";
 import {
   AssetInput,
   ContractDefinitionInput,
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
   PolicyDefinitionInput,
 } from "../../../src";
 
 describe("CatalogController", () => {
   const providerProtocolUrl = "http://provider-connector:9194/protocol";
 
-  const consumerManagement = new EdcConnectorClientBuilder()
+  const consumerManagement = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .build()
     .management;
 
-  const providerManagement = new EdcConnectorClientBuilder()
+  const providerManagement = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
     .build()

--- a/tests/controllers/management-tests/catalog.test.ts
+++ b/tests/controllers/management-tests/catalog.test.ts
@@ -1,40 +1,30 @@
 import * as crypto from "node:crypto";
 import {
-  Addresses,
   AssetInput,
   ContractDefinitionInput,
-  EdcConnectorClient,
+  EdcConnectorClientBuilder,
   PolicyDefinitionInput,
 } from "../../../src";
 
-describe("ManagementController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
-  const provider: Addresses = {
-    default: "http://localhost:29191/api",
-    management: "http://localhost:29193/management",
-    protocol: "http://provider-connector:9194/protocol",
-    public: "http://localhost:29291/public",
-    control: "http://localhost:29292/control",
-  };
+describe("CatalogController", () => {
+  const providerProtocolUrl = "http://provider-connector:9194/protocol";
 
-  const edcClient = new EdcConnectorClient();
+  const consumerManagement = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .build()
+    .management;
 
-  describe("edcClient.management.catalog.queryAll", () => {
+  const providerManagement = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:29193/management")
+    .build()
+    .management;
+
+  describe("queryAll", () => {
     it("returns the catalog for a target provider", async () => {
       // given
-      const consumerContext = edcClient.createContext(apiToken, consumer);
-      const providerContext = edcClient.createContext(apiToken, provider);
-      const assetId = crypto.randomUUID();
-
       const assetInput: AssetInput = {
-        "@id": assetId,
         properties: {
           name: "product description",
           contenttype: "application/json",
@@ -45,7 +35,7 @@ describe("ManagementController", () => {
           type: "HttpData",
         },
       };
-      await edcClient.management.assets.create(providerContext, assetInput);
+      await providerManagement.assets.create(assetInput);
 
       const policyId = crypto.randomUUID();
       const policyInput: PolicyDefinitionInput = {
@@ -54,7 +44,6 @@ describe("ManagementController", () => {
           uid: "231802-bb34-11ec-8422-0242ac120002",
           permissions: [
             {
-              target: assetId,
               action: {
                 type: "USE",
               },
@@ -63,10 +52,7 @@ describe("ManagementController", () => {
           ],
         },
       };
-      await edcClient.management.policyDefinitions.create(
-        providerContext,
-        policyInput,
-      );
+      await providerManagement.policyDefinitions.create(policyInput);
 
       const contractDefinitionId = crypto.randomUUID();
       const contractDefinitionInput: ContractDefinitionInput = {
@@ -75,16 +61,14 @@ describe("ManagementController", () => {
         contractPolicyId: policyId,
         assetsSelector: [],
       };
-      await edcClient.management.contractDefinitions.create(
-        providerContext,
+      await providerManagement.contractDefinitions.create(
         contractDefinitionInput,
       );
 
       // when
-      const catalog = await edcClient.management.catalog.queryAll(
-        consumerContext,
+      const catalog = await consumerManagement.catalog.request(
         {
-          providerUrl: provider.protocol,
+          providerUrl: providerProtocolUrl,
         },
       );
 

--- a/tests/controllers/management-tests/contract-agreements.test.ts
+++ b/tests/controllers/management-tests/contract-agreements.test.ts
@@ -1,5 +1,5 @@
 import * as crypto from "node:crypto";
-import { EdcConnectorClientBuilder } from "../../../src";
+import { EdcConnectorClient } from "../../../src";
 import {
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
@@ -12,13 +12,13 @@ import {
 
 describe("ContractAgreementController", () => {
 
-  const consumer = new EdcConnectorClientBuilder()
+  const consumer = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .protocolUrl("http://consumer-connector:9194/protocol")
     .build();
 
-  const provider = new EdcConnectorClientBuilder()
+  const provider = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
     .protocolUrl("http://provider-connector:9194/protocol")

--- a/tests/controllers/management-tests/contract-agreements.test.ts
+++ b/tests/controllers/management-tests/contract-agreements.test.ts
@@ -1,5 +1,5 @@
 import * as crypto from "node:crypto";
-import { Addresses, EdcConnectorClient } from "../../../src";
+import { EdcConnectorClientBuilder } from "../../../src";
 import {
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
@@ -10,50 +10,31 @@ import {
   waitForNegotiationState,
 } from "../../test-utils";
 
-describe("ManagementController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
-  const provider: Addresses = {
-    default: "http://localhost:29191/api",
-    management: "http://localhost:29193/management",
-    protocol: "http://provider-connector:9194/protocol",
-    public: "http://localhost:29291/public",
-    control: "http://localhost:29292/control",
-  };
+describe("ContractAgreementController", () => {
 
-  const edcClient = new EdcConnectorClient();
+  const consumer = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .protocolUrl("http://consumer-connector:9194/protocol")
+    .build();
 
-  describe("edcClient.management.contractAgreements.queryAll", () => {
+  const provider = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:29193/management")
+    .protocolUrl("http://provider-connector:9194/protocol")
+    .build();
+
+  describe("queryAll", () => {
     it("retrieves all contract agreements", async () => {
       // given
-      const consumerContext = edcClient.createContext(apiToken, consumer);
-      const providerContext = edcClient.createContext(apiToken, provider);
-      const { idResponse } = await createContractNegotiation(
-        edcClient,
-        providerContext,
-        consumerContext,
-      );
-      await waitForNegotiationState(
-        edcClient,
-        consumerContext,
-        idResponse.id,
-        "FINALIZED",
-      );
+      const { idResponse } = await createContractNegotiation(provider, consumer);
+      await waitForNegotiationState(consumer, idResponse.id, "FINALIZED");
       const contractNegotiation =
-        await edcClient.management.contractNegotiations.get(
-          consumerContext,
-          idResponse.id,
-        );
+        await consumer.management.contractNegotiations.get(idResponse.id,);
 
       // when
       const contractAgreements =
-        await edcClient.management.contractAgreements.queryAll(consumerContext);
+        await consumer.management.contractAgreements.queryAll();
 
       // then
       expect(contractAgreements.length).toBeGreaterThan(0);
@@ -66,19 +47,11 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.getAgreement", () => {
+  describe("getAgreement", () => {
     it("retrieves target contract agreement", async () => {
-      // given
-      const consumerContext = edcClient.createContext(apiToken, consumer);
-      const providerContext = edcClient.createContext(apiToken, provider);
-
       // when
       const { contractNegotiation, contractAgreement } =
-        await createContractAgreement(
-          edcClient,
-          providerContext,
-          consumerContext,
-        );
+        await createContractAgreement(provider, consumer);
 
       // then
       expect(contractAgreement).toHaveProperty(
@@ -88,12 +61,8 @@ describe("ManagementController", () => {
     });
 
     it("fails to fetch an not existent contract negotiation", async () => {
-      // given
-      const context = edcClient.createContext(apiToken, consumer);
-
       // when
-      const maybeAsset = edcClient.management.contractAgreements.get(
-        context,
+      const maybeAsset = consumer.management.contractAgreements.get(
         crypto.randomUUID(),
       );
 

--- a/tests/controllers/management-tests/contract-definitions.test.ts
+++ b/tests/controllers/management-tests/contract-definitions.test.ts
@@ -1,31 +1,23 @@
 import * as crypto from "node:crypto";
 import {
-  Addresses,
   ContractDefinitionInput,
   EDC_NAMESPACE,
-  EdcConnectorClient,
+  EdcConnectorClientBuilder,
 } from "../../../src";
 import {
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
 } from "../../../src/error";
 
-describe("ManagementController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
+describe("ContractDefinitionController", () => {
+  const edcClient = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .build();
 
-  const edcClient = new EdcConnectorClient();
-
-  describe("edcClient.management.contractDefinitions.create", () => {
+  describe("create", () => {
     it("succesfully creates a new contract definition", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         "@id": crypto.randomUUID(),
         accessPolicyId: crypto.randomUUID(),
@@ -35,7 +27,6 @@ describe("ManagementController", () => {
 
       // when
       const idResponse = await edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
 
@@ -46,7 +37,6 @@ describe("ManagementController", () => {
 
     it("fails creating two contract definitions with the same id", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         "@id": crypto.randomUUID(),
         accessPolicyId: crypto.randomUUID(),
@@ -56,11 +46,9 @@ describe("ManagementController", () => {
 
       // when
       await edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
       const maybeCreateResult = edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
 
@@ -79,10 +67,9 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.contractDefinitions.queryAll", () => {
+  describe("queryAll", () => {
     it("succesfully retuns a list of contract definitions", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         "@id": "definition-" + crypto.randomUUID(),
         accessPolicyId: crypto.randomUUID(),
@@ -90,13 +77,12 @@ describe("ManagementController", () => {
         assetsSelector: [],
       };
       await edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
 
       // when
       const contractDefinitions =
-        await edcClient.management.contractDefinitions.queryAll(context);
+        await edcClient.management.contractDefinitions.queryAll();
 
       // then
       expect(contractDefinitions.length).toBeGreaterThan(0);
@@ -109,10 +95,9 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.contractDefinitions.get", () => {
+  describe("get", () => {
     it("succesfully retuns a target contract definition", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         "@id": crypto.randomUUID(),
         accessPolicyId: crypto.randomUUID(),
@@ -120,14 +105,12 @@ describe("ManagementController", () => {
         assetsSelector: [],
       };
       const idResponse = await edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
 
       // when
       const contractDefinition =
         await edcClient.management.contractDefinitions.get(
-          context,
           idResponse.id,
         );
 
@@ -136,12 +119,8 @@ describe("ManagementController", () => {
     });
 
     it("fails to fetch an not existant contract definition", async () => {
-      // given
-      const context = edcClient.createContext(apiToken, consumer);
-
       // when
       const maybePolicy = edcClient.management.contractDefinitions.get(
-        context,
         crypto.randomUUID(),
       );
 
@@ -158,10 +137,9 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.contractDefinitions.delete", () => {
+  describe("delete", () => {
     it("deletes a target contract definition", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const contractDefinitionInput: ContractDefinitionInput = {
         "@id": crypto.randomUUID(),
         accessPolicyId: crypto.randomUUID(),
@@ -169,14 +147,12 @@ describe("ManagementController", () => {
         assetsSelector: [],
       };
       const idResponse = await edcClient.management.contractDefinitions.create(
-        context,
         contractDefinitionInput,
       );
 
       // when
       const contractDefinition =
         await edcClient.management.contractDefinitions.delete(
-          context,
           idResponse.id,
         );
 
@@ -185,13 +161,9 @@ describe("ManagementController", () => {
     });
 
     it("fails to delete an not existant contract definition", async () => {
-      // given
-      const context = edcClient.createContext(apiToken, consumer);
-
       // when
       const maybeContractDefinition =
         edcClient.management.contractDefinitions.delete(
-          context,
           crypto.randomUUID(),
         );
 
@@ -212,7 +184,6 @@ describe("ManagementController", () => {
     describe("edcClient.management.updateContractDefinition", () => {
       it("updates a target contract definition", async () => {
         // given
-        const context = edcClient.createContext(apiToken, consumer);
         const contractDefinitionInput: ContractDefinitionInput = {
           "@id": crypto.randomUUID(),
           accessPolicyId: crypto.randomUUID(),
@@ -221,7 +192,6 @@ describe("ManagementController", () => {
         };
 
         await edcClient.management.contractDefinitions.create(
-          context,
           contractDefinitionInput,
         );
         const updateContractDefinitionInput = {
@@ -233,13 +203,11 @@ describe("ManagementController", () => {
 
         // when
         await edcClient.management.contractDefinitions.update(
-          context,
           updateContractDefinitionInput,
         );
 
         const updatedContractDefinition =
           await edcClient.management.contractDefinitions.get(
-            context,
             updateContractDefinitionInput["@id"] as string,
           );
 
@@ -258,7 +226,6 @@ describe("ManagementController", () => {
 
       it("fails to update an inexistant contract definition", async () => {
         // given
-        const context = edcClient.createContext(apiToken, consumer);
         const updateContractDefinitionInput = {
           "@id": crypto.randomUUID(),
           accessPolicyId: crypto.randomUUID(),
@@ -269,7 +236,6 @@ describe("ManagementController", () => {
         // when
         const maybeUpdatedContractDefinition =
           edcClient.management.contractDefinitions.update(
-            context,
             updateContractDefinitionInput,
           );
 

--- a/tests/controllers/management-tests/contract-definitions.test.ts
+++ b/tests/controllers/management-tests/contract-definitions.test.ts
@@ -2,7 +2,7 @@ import * as crypto from "node:crypto";
 import {
   ContractDefinitionInput,
   EDC_NAMESPACE,
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
 } from "../../../src";
 import {
   EdcConnectorClientError,
@@ -10,7 +10,7 @@ import {
 } from "../../../src/error";
 
 describe("ContractDefinitionController", () => {
-  const edcClient = new EdcConnectorClientBuilder()
+  const edcClient = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .build();

--- a/tests/controllers/management-tests/contract-negotiations.test.ts
+++ b/tests/controllers/management-tests/contract-negotiations.test.ts
@@ -1,5 +1,5 @@
 import * as crypto from "node:crypto";
-import { EdcConnectorClientBuilder } from "../../../src";
+import { EdcConnectorClient } from "../../../src";
 import {
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
@@ -11,13 +11,13 @@ import {
 } from "../../test-utils";
 
 describe("ContractNegotiationController", () => {
-  const consumer = new EdcConnectorClientBuilder()
+  const consumer = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .protocolUrl("http://consumer-connector:9194/protocol")
     .build();
 
-  const provider = new EdcConnectorClientBuilder()
+  const provider = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
     .protocolUrl("http://provider-connector:9194/protocol")

--- a/tests/controllers/management-tests/policy-definitions.test.ts
+++ b/tests/controllers/management-tests/policy-definitions.test.ts
@@ -1,7 +1,6 @@
 import * as crypto from "node:crypto";
 import {
-  Addresses,
-  EdcConnectorClient,
+  EdcConnectorClientBuilder,
   PolicyDefinitionInput,
 } from "../../../src";
 import {
@@ -9,32 +8,24 @@ import {
   EdcConnectorClientErrorType,
 } from "../../../src/error";
 
-describe("ManagementController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
+describe("PolicyDefinitionController", () => {
+  const edcClient = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .build();
 
-  const edcClient = new EdcConnectorClient();
+  const policyDefinitions = edcClient.management.policyDefinitions;
 
-  describe("edcClient.management.policyDefinitions.create", () => {
+  describe("create", () => {
     it("succesfully creates a new policy", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         "@id": crypto.randomUUID(),
         policy: {},
       };
 
       // when
-      const idResponse = await edcClient.management.policyDefinitions.create(
-        context,
-        policyInput,
-      );
+      const idResponse = await policyDefinitions.create(policyInput);
 
       // then
       expect(idResponse).toHaveProperty("createdAt");
@@ -43,16 +34,14 @@ describe("ManagementController", () => {
 
     it("fails creating two policies with the same id", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         "@id": crypto.randomUUID(),
         policy: {},
       };
 
       // when
-      await edcClient.management.policyDefinitions.create(context, policyInput);
+      await policyDefinitions.create(policyInput);
       const maybeCreateResult = edcClient.management.policyDefinitions.create(
-        context,
         policyInput,
       );
 
@@ -71,20 +60,17 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.policyDefinitions.queryAll", () => {
+  describe("queryAll", () => {
     it("succesfully retuns a list of assets", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         "@id": crypto.randomUUID(),
         policy: {},
       };
-      await edcClient.management.policyDefinitions.create(context, policyInput);
+      await policyDefinitions.create(policyInput);
 
       // when
-      const policies = await edcClient.management.policyDefinitions.queryAll(
-        context,
-      );
+      const policies = await policyDefinitions.queryAll();
 
       // then
       expect(policies.length).toBeGreaterThan(0);
@@ -94,22 +80,19 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.policyDefinitions.get", () => {
+  describe("get", () => {
     it("succesfully retuns a target policy", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         "@id": crypto.randomUUID(),
         policy: {},
       };
-      const idResponse = await edcClient.management.policyDefinitions.create(
-        context,
+      const idResponse = await policyDefinitions.create(
         policyInput,
       );
 
       // when
-      const policy = await edcClient.management.policyDefinitions.get(
-        context,
+      const policy = await policyDefinitions.get(
         idResponse.id,
       );
 
@@ -119,11 +102,9 @@ describe("ManagementController", () => {
 
     it("fails to fetch an not existant policy", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
 
       // when
       const maybePolicy = edcClient.management.policyDefinitions.get(
-        context,
         crypto.randomUUID(),
       );
 
@@ -140,19 +121,17 @@ describe("ManagementController", () => {
     });
   });
 
-  describe("edcClient.management.policyDefinitions.delete", () => {
+  describe("delete", () => {
     it("deletes a target policy", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const policyInput: PolicyDefinitionInput = {
         "@id": crypto.randomUUID(),
         policy: {},
       };
-      await edcClient.management.policyDefinitions.create(context, policyInput);
+      await policyDefinitions.create(policyInput);
 
       // when
-      const policy = await edcClient.management.policyDefinitions.delete(
-        context,
+      const policy = await policyDefinitions.delete(
         policyInput["@id"]!,
       );
 
@@ -162,11 +141,9 @@ describe("ManagementController", () => {
 
     it("fails to delete an not existant policy", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
 
       // when
       const maybeAsset = edcClient.management.policyDefinitions.delete(
-        context,
         crypto.randomUUID(),
       );
 

--- a/tests/controllers/management-tests/policy-definitions.test.ts
+++ b/tests/controllers/management-tests/policy-definitions.test.ts
@@ -1,6 +1,6 @@
 import * as crypto from "node:crypto";
 import {
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
   PolicyDefinitionInput,
 } from "../../../src";
 import {
@@ -9,7 +9,7 @@ import {
 } from "../../../src/error";
 
 describe("PolicyDefinitionController", () => {
-  const edcClient = new EdcConnectorClientBuilder()
+  const edcClient = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .build();

--- a/tests/controllers/management-tests/transfer-processes.test.ts
+++ b/tests/controllers/management-tests/transfer-processes.test.ts
@@ -1,6 +1,6 @@
 import {
   EDC_NAMESPACE,
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
   TransferProcessStates,
 } from "../../../src";
 import {
@@ -9,13 +9,13 @@ import {
 } from "../../test-utils";
 
 describe("TransferProcessController", () => {
-  const consumer = new EdcConnectorClientBuilder()
+  const consumer = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .protocolUrl("http://consumer-connector:9194/protocol")
     .build();
 
-  const provider = new EdcConnectorClientBuilder()
+  const provider = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
     .protocolUrl("http://provider-connector:9194/protocol")

--- a/tests/controllers/management-tests/transfer-processes.test.ts
+++ b/tests/controllers/management-tests/transfer-processes.test.ts
@@ -1,7 +1,6 @@
 import {
-  Addresses,
   EDC_NAMESPACE,
-  EdcConnectorClient,
+  EdcConnectorClientBuilder,
   TransferProcessStates,
 } from "../../../src";
 import {
@@ -9,24 +8,18 @@ import {
   createReceiverServer,
 } from "../../test-utils";
 
-describe("ManagementController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
-  const provider: Addresses = {
-    default: "http://localhost:29191/api",
-    management: "http://localhost:29193/management",
-    protocol: "http://provider-connector:9194/protocol",
-    public: "http://localhost:29291/public",
-    control: "http://localhost:29292/control",
-  };
+describe("TransferProcessController", () => {
+  const consumer = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .protocolUrl("http://consumer-connector:9194/protocol")
+    .build();
 
-  const edcClient = new EdcConnectorClient();
+  const provider = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:29193/management")
+    .protocolUrl("http://provider-connector:9194/protocol")
+    .build();
 
   describe("with receiver server", () => {
     const receiverServer = createReceiverServer();
@@ -39,11 +32,9 @@ describe("ManagementController", () => {
       await receiverServer.shutdown();
     });
 
-    describe("edcClient.management.transferProcesses.queryAll", () => {
+    describe("queryAll", () => {
       it("retrieves all tranfer processes", async () => {
         // given
-        const consumerContext = edcClient.createContext(apiToken, consumer);
-        const providerContext = edcClient.createContext(apiToken, provider);
         const dataplaneInput = {
           id: "provider-dataplane",
           url: "http://provider-connector:9192/control/transfer",
@@ -54,24 +45,17 @@ describe("ManagementController", () => {
           },
         };
 
-        await edcClient.management.dataplanes.register(
-          providerContext,
-          dataplaneInput,
-        );
+        await provider.management.dataplanes.register(dataplaneInput);
 
         const { assetId, contractAgreement } = await createContractAgreement(
-          edcClient,
-          providerContext,
-          consumerContext,
-        );
+          provider, consumer);
 
         const idResponse =
-          await edcClient.management.transferProcesses.initiate(
-            consumerContext,
+          await consumer.management.transferProcesses.initiate(
             {
               assetId,
               connectorId: "provider",
-              connectorAddress: providerContext.protocol,
+              connectorAddress: provider.addresses.protocol!,
               contractId: contractAgreement.id,
               managedResources: false,
               dataDestination: { type: "HttpProxy" },
@@ -80,9 +64,7 @@ describe("ManagementController", () => {
 
         // when
         const transferProcesses =
-          await edcClient.management.transferProcesses.queryAll(
-            consumerContext,
-          );
+          await consumer.management.transferProcesses.queryAll();
 
         // then
         expect(transferProcesses.length).toBeGreaterThan(0);
@@ -95,10 +77,53 @@ describe("ManagementController", () => {
     });
   });
 
+  describe("getState", () => {
+    it("successfully gets a transfer process state", async () => {
+      // given
+      const dataplaneInput = {
+        id: "provider-dataplane",
+        url: "http://provider-connector:9192/control/transfer",
+        allowedSourceTypes: ["HttpData"],
+        allowedDestTypes: ["HttpProxy", "HttpData"],
+        properties: {
+          publicApiUrl: "http://provider-connector:9291/public/",
+        },
+      };
+
+      await provider.management.dataplanes.register(
+        dataplaneInput,
+      );
+
+      const { assetId, contractAgreement } = await createContractAgreement(
+        provider, consumer);
+
+      const idResponse = await consumer.management.transferProcesses.initiate(
+        {
+          assetId,
+          connectorId: "provider",
+          connectorAddress: provider.addresses.protocol!,
+          contractId: contractAgreement.id,
+          managedResources: false,
+          dataDestination: { type: "HttpProxy" },
+        },
+      );
+
+      // when
+      const transferProcessState =
+        await consumer.management.transferProcesses.getState(
+          idResponse["@id"],
+        );
+
+      // then
+      expect(Object.values(TransferProcessStates)).toContain(
+        transferProcessState[`${EDC_NAMESPACE}:state`],
+      );
+    });
+  });
+
   describe("edcClient.management.dataplanes.register", () => {
     it("succesfully register a dataplane", async () => {
       // given
-      const context = edcClient.createContext(apiToken, consumer);
       const dataplaneInput = {
         id: "consumer-dataplane",
         url: "http://consumer-connector:9192/control/transfer",
@@ -110,8 +135,7 @@ describe("ManagementController", () => {
       };
 
       // when
-      const registration = await edcClient.management.dataplanes.register(
-        context,
+      const registration = await consumer.management.dataplanes.register(
         dataplaneInput,
       );
 
@@ -122,7 +146,6 @@ describe("ManagementController", () => {
 
   describe("edcClient.management.dataplanes.list", () => {
     it("succesfully list available dataplanes", async () => {
-      const context = edcClient.createContext(apiToken, consumer);
       const input = {
         url: "http://consumer-connector:9192/control/transfer",
         allowedSourceTypes: ["HttpData"],
@@ -131,9 +154,9 @@ describe("ManagementController", () => {
           publicApiUrl: "http://consumer-connector:9291/public/",
         },
       };
-      await edcClient.management.dataplanes.register(context, input);
+      await consumer.management.dataplanes.register(input);
 
-      const dataplanes = await edcClient.management.dataplanes.list(context);
+      const dataplanes = await consumer.management.dataplanes.list();
 
       expect(dataplanes.length).toBeGreaterThan(0);
       dataplanes.forEach((dataplane) => {
@@ -152,58 +175,6 @@ describe("ManagementController", () => {
           "http://consumer-connector:9291/public/",
         );
       });
-    });
-  });
-
-  describe("edcClient.management.transferProcesses.getState", () => {
-    it("successfully gets a transfer process state", async () => {
-      // given
-      const consumerContext = edcClient.createContext(apiToken, consumer);
-      const providerContext = edcClient.createContext(apiToken, provider);
-      const dataplaneInput = {
-        id: "provider-dataplane",
-        url: "http://provider-connector:9192/control/transfer",
-        allowedSourceTypes: ["HttpData"],
-        allowedDestTypes: ["HttpProxy", "HttpData"],
-        properties: {
-          publicApiUrl: "http://provider-connector:9291/public/",
-        },
-      };
-
-      await edcClient.management.dataplanes.register(
-        providerContext,
-        dataplaneInput,
-      );
-
-      const { assetId, contractAgreement } = await createContractAgreement(
-        edcClient,
-        providerContext,
-        consumerContext,
-      );
-
-      const idResponse = await edcClient.management.transferProcesses.initiate(
-        consumerContext,
-        {
-          assetId,
-          connectorId: "provider",
-          connectorAddress: providerContext.protocol,
-          contractId: contractAgreement.id,
-          managedResources: false,
-          dataDestination: { type: "HttpProxy" },
-        },
-      );
-
-      // when
-      const transferProcessState =
-        await edcClient.management.transferProcesses.getState(
-          consumerContext,
-          idResponse["@id"],
-        );
-
-      // then
-      expect(Object.values(TransferProcessStates)).toContain(
-        transferProcessState[`${EDC_NAMESPACE}:state`],
-      );
     });
   });
 });

--- a/tests/controllers/observability.test.ts
+++ b/tests/controllers/observability.test.ts
@@ -1,7 +1,7 @@
-import { EdcConnectorClientBuilder } from "../../src";
+import { EdcConnectorClient } from "../../src";
 
 describe("ObservabilityController", () => {
-    const edcClient = new EdcConnectorClientBuilder()
+    const edcClient = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .defaultUrl("http://localhost:19191/api")
     .build();

--- a/tests/controllers/observability.test.ts
+++ b/tests/controllers/observability.test.ts
@@ -1,23 +1,15 @@
-import { Addresses, EdcConnectorClient } from "../../src";
+import { EdcConnectorClientBuilder } from "../../src";
 
 describe("ObservabilityController", () => {
-  const apiToken = "123456";
-  const addresses: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
+    const edcClient = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .defaultUrl("http://localhost:19191/api")
+    .build();
 
   describe("edcClient.observability.checkHealth", () => {
     it("succesfully return a HealthStatus response", async () => {
-      // given
-      const edcClient = new EdcConnectorClient();
-      const context = edcClient.createContext(apiToken, addresses);
-
       // when
-      const healthStatus = await edcClient.observability.checkHealth(context);
+      const healthStatus = await edcClient.observability.checkHealth();
 
       // then
       expect(healthStatus).toBeTruthy();
@@ -26,12 +18,8 @@ describe("ObservabilityController", () => {
 
   describe("edcClient.observability.checkLiveness", () => {
     it("succesfully return a HealthStatus response", async () => {
-      // given
-      const edcClient = new EdcConnectorClient();
-      const context = edcClient.createContext(apiToken, addresses);
-
       // when
-      const healthStatus = await edcClient.observability.checkLiveness(context);
+      const healthStatus = await edcClient.observability.checkLiveness();
 
       // then
       expect(healthStatus).toBeTruthy();
@@ -40,14 +28,8 @@ describe("ObservabilityController", () => {
 
   describe("edcClient.observability.checkReadiness", () => {
     it("succesfully return a HealthStatus response", async () => {
-      // given
-      const edcClient = new EdcConnectorClient();
-      const context = edcClient.createContext(apiToken, addresses);
-
       // when
-      const healthStatus = await edcClient.observability.checkReadiness(
-        context,
-      );
+      const healthStatus = await edcClient.observability.checkReadiness();
 
       // then
       expect(healthStatus).toBeTruthy();
@@ -56,12 +38,8 @@ describe("ObservabilityController", () => {
 
   describe("edcClient.observability.checkStartup", () => {
     it("succesfully return a HealthStatus response", async () => {
-      // given
-      const edcClient = new EdcConnectorClient();
-      const context = edcClient.createContext(apiToken, addresses);
-
       // when
-      const healthStatus = await edcClient.observability.checkStartup(context);
+      const healthStatus = await edcClient.observability.checkStartup();
 
       // then
       expect(healthStatus).toBeTruthy();

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -1,22 +1,21 @@
 import {
-  EdcConnectorClientBuilder,
+  EdcConnectorClient,
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
 } from "../../src";
 import { createContractAgreement, createReceiverServer } from "../test-utils";
 
 describe("PublicController", () => {
-  const consumer = new EdcConnectorClientBuilder()
+  const consumer = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
-    .protocolUrl("http://consumer-connector:9194/protocol")
     .build();
 
-  const provider = new EdcConnectorClientBuilder()
+  const provider = new EdcConnectorClient.Builder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
-    .protocolUrl("http://provider-connector:9194/protocol")
     .publicUrl("http://localhost:29291/public")
+    .protocolUrl("http://provider-connector:9194/protocol")
     .build();
 
   const receiverServer = createReceiverServer();

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -10,6 +10,7 @@ describe("PublicController", () => {
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .protocolUrl("http://consumer-connector:9194/protocol")
+    .publicUrl("http://localhost:19291/public")
     .build();
 
   const provider = new EdcConnectorClientBuilder()

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -1,27 +1,22 @@
 import {
-  Addresses,
-  EdcConnectorClient,
+  EdcConnectorClientBuilder,
   EdcConnectorClientError,
   EdcConnectorClientErrorType,
 } from "../../src";
 import { createContractAgreement, createReceiverServer } from "../test-utils";
 
 describe("PublicController", () => {
-  const apiToken = "123456";
-  const consumer: Addresses = {
-    default: "http://localhost:19191/api",
-    management: "http://localhost:19193/management",
-    protocol: "http://consumer-connector:9194/protocol",
-    public: "http://localhost:19291/public",
-    control: "http://localhost:19292/control",
-  };
-  const provider: Addresses = {
-    default: "http://localhost:29191/api",
-    management: "http://localhost:29193/management",
-    protocol: "http://provider-connector:9194/protocol",
-    public: "http://localhost:29291/public",
-    control: "http://localhost:29292/control",
-  };
+  const consumer = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:19193/management")
+    .protocolUrl("http://consumer-connector:9194/protocol")
+    .build();
+
+  const provider = new EdcConnectorClientBuilder()
+    .apiToken("123456")
+    .managementUrl("http://localhost:29193/management")
+    .protocolUrl("http://provider-connector:9194/protocol")
+    .build();
 
   const receiverServer = createReceiverServer();
 
@@ -35,12 +30,8 @@ describe("PublicController", () => {
 
   describe("edcClient.public.getTransferredData", () => {
     it("fails to return an object in response", async () => {
-      // given
-      const edcClient = new EdcConnectorClient();
-      const context = edcClient.createContext(apiToken, consumer);
-
       // when
-      const maybeData = edcClient.public.getTransferredData(context, {});
+      const maybeData = consumer.public.getTransferredData({});
 
       // then
       await expect(maybeData).rejects.toThrowError("request was malformed");
@@ -56,10 +47,6 @@ describe("PublicController", () => {
 
     it("initiate the transfer process", async () => {
       // given
-      const edcClient = new EdcConnectorClient();
-
-      const consumerContext = edcClient.createContext(apiToken, consumer);
-      const providerContext = edcClient.createContext(apiToken, provider);
       const dataplaneInput = {
         id: "provider-dataplane",
         url: "http://provider-connector:9192/control/transfer",
@@ -70,23 +57,17 @@ describe("PublicController", () => {
         },
       };
 
-      await edcClient.management.dataplanes.register(
-        providerContext,
-        dataplaneInput,
-      );
+      await provider.management.dataplanes.register(dataplaneInput);
 
       const { assetId, contractAgreement } = await createContractAgreement(
-        edcClient,
-        providerContext,
-        consumerContext,
+        provider, consumer
       );
 
-      const idResponse = await edcClient.management.transferProcesses.initiate(
-        consumerContext,
+      const idResponse = await consumer.management.transferProcesses.initiate(
         {
           assetId,
           connectorId: "provider",
-          connectorAddress: providerContext.protocol,
+          connectorAddress: provider.addresses.protocol!,
           contractId: contractAgreement.id,
           managedResources: false,
           dataDestination: { type: "HttpProxy" },
@@ -98,7 +79,7 @@ describe("PublicController", () => {
       );
 
       // when
-      const data = await edcClient.public.getTransferredData(consumerContext, {
+      const data = await consumer.public.getTransferredData({
         [transferProcessResponse.authKey]: transferProcessResponse.authCode,
       });
 

--- a/tests/controllers/public.test.ts
+++ b/tests/controllers/public.test.ts
@@ -10,13 +10,13 @@ describe("PublicController", () => {
     .apiToken("123456")
     .managementUrl("http://localhost:19193/management")
     .protocolUrl("http://consumer-connector:9194/protocol")
-    .publicUrl("http://localhost:19291/public")
     .build();
 
   const provider = new EdcConnectorClientBuilder()
     .apiToken("123456")
     .managementUrl("http://localhost:29193/management")
     .protocolUrl("http://provider-connector:9194/protocol")
+    .publicUrl("http://localhost:29291/public")
     .build();
 
   const receiverServer = createReceiverServer();
@@ -32,7 +32,7 @@ describe("PublicController", () => {
   describe("edcClient.public.getTransferredData", () => {
     it("fails to return an object in response", async () => {
       // when
-      const maybeData = consumer.public.getTransferredData({});
+      const maybeData = provider.public.getTransferredData({});
 
       // then
       await expect(maybeData).rejects.toThrowError("request was malformed");
@@ -80,7 +80,7 @@ describe("PublicController", () => {
       );
 
       // when
-      const data = await consumer.public.getTransferredData({
+      const data = await provider.public.getTransferredData({
         [transferProcessResponse.authKey]: transferProcessResponse.authCode,
       });
 


### PR DESCRIPTION
## Description
Make the `EdcConnectorClientContext` optional in the Controllers.
Introduce an `EdcConnectorClientBuilder` to being able to build up a client easily with a built-in context.

## Notes
- This will be a breaking change because unfortunately context parameters were not put as last argument of the methods.

Closes #72