### PR TITLE
fix: export policy types

### DIFF
--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -13,6 +13,7 @@ export * from "./dataplane";
 export * from "./id-response";
 export * from "./jsonld";
 export * from "./health";
+export * from "./policy";
 export * from "./policydefinition";
 export * from "./transfer-process";
 

--- a/src/entities/policydefinition.ts
+++ b/src/entities/policydefinition.ts
@@ -1,5 +1,5 @@
 import { JsonLdId } from "./jsonld";
-import { Policy ,PolicyInput } from "./policy";
+import { Policy, PolicyInput } from "./policy";
 
 export class PolicyDefinition extends JsonLdId {
 


### PR DESCRIPTION
## Description
Export the policy types that were moved into a folder.

Otherwise they cannot be used.