### PR TITLE
fix: policy typo

### DIFF
--- a/src/entities/policy/policy.ts
+++ b/src/entities/policy/policy.ts
@@ -16,9 +16,9 @@ export interface PolicyInput {
   assigner?: string;
   extensibleProperties?: object;
   inheritsFrom?: string;
-  obligations?: Duty[];
+  obligation?: Duty[];
   permission?: Permission[];
-  prohibitions?: Prohibition[];
+  prohibition?: Prohibition[];
   target?: string;
 }
 
@@ -26,5 +26,13 @@ export class Policy extends JsonLdObject {
 
   get permissions(): JsonLdObject[] {
     return this.arrayOf(() => new JsonLdObject(), "odrl", "permission");
+  }
+
+  get prohibitions(): JsonLdObject[] {
+    return this.arrayOf(() => new JsonLdObject(), "odrl", "prohibition");
+  }
+
+  get obligations(): JsonLdObject[] {
+    return this.arrayOf(() => new JsonLdObject(), "odrl", "obligation");
   }
 }

--- a/tests/controllers/management-tests/policy-definitions.test.ts
+++ b/tests/controllers/management-tests/policy-definitions.test.ts
@@ -110,6 +110,30 @@ describe("PolicyDefinitionController", () => {
                 }
               ]
             }
+          ],
+          prohibition: [
+            {
+              action: "use",
+              constraint: [
+                {
+                  leftOperand: "field",
+                  operator: "eq",
+                  rightOperand: "value"
+                }
+              ]
+            }
+          ],
+          obligation: [
+            {
+              action: "use",
+              constraint: [
+                {
+                  leftOperand: "field",
+                  operator: "eq",
+                  rightOperand: "value"
+                }
+              ]
+            }
           ]
         },
       };
@@ -121,10 +145,16 @@ describe("PolicyDefinitionController", () => {
       // then
       expect(policyDefinition.id).toBe(idResponse.id);
       expect(policyDefinition.policy.permissions).toHaveLength(1);
-      const constraints = policyDefinition.policy.permissions[0].array("odrl", "constraint");
-      expect(constraints).toHaveLength(2);
-      expect(constraints[0].mandatoryValue("odrl", "leftOperand")).toBe("https://w3id.org/edc/v0.0.1/ns/field");
-      expect(constraints[1].array("odrl", "and")).toHaveLength(2);
+      const permissionConstraints = policyDefinition.policy.permissions[0].array("odrl", "constraint");
+      expect(permissionConstraints).toHaveLength(2);
+      expect(permissionConstraints[0].mandatoryValue("odrl", "leftOperand")).toBe("https://w3id.org/edc/v0.0.1/ns/field");
+      expect(permissionConstraints[1].array("odrl", "and")).toHaveLength(2);
+      expect(policyDefinition.policy.prohibitions).toHaveLength(1);
+      const prohibitionsConstraints = policyDefinition.policy.prohibitions[0].array("odrl", "constraint");
+      expect(prohibitionsConstraints).toHaveLength(1);
+      expect(policyDefinition.policy.obligations).toHaveLength(1);
+      const obligationsConstraints = policyDefinition.policy.obligations[0].array("odrl", "constraint");
+      expect(obligationsConstraints).toHaveLength(1);
     });
 
     it("fails to fetch an not existant policy", async () => {


### PR DESCRIPTION
## Description
fix typo for `prohibition` and `obligation`, add missing method on the `Policy` type

Closes #100 
