### PR TITLE
feat: allow Connector's addresses to be relative URLs

### DIFF
--- a/src/facades/management.ts
+++ b/src/facades/management.ts
@@ -32,10 +32,10 @@ export class ManagementController extends EdcController {
     return new DataplaneController(this.inner, this.context);
   }
   get edrs(): EdrController {
-    return new EdrController(this.#inner, this.#context);
+    return new EdrController(this.inner, this.context);
   }
   get secrets(): SecretController {
-    return new SecretController(this.#inner, this.#context);
+    return new SecretController(this.inner, this.context);
   }
   get policyDefinitions() {
     return new PolicyDefinitionController(this.inner, this.context);

--- a/src/inner.ts
+++ b/src/inner.ts
@@ -45,13 +45,14 @@ export class Inner {
   }
 
   async #fetch(baseUrl: string, innerRequest: InnerRequest): Promise<Response> {
-    const url = new URL(`${baseUrl}${innerRequest.path}`);
-
+    const searchParams = new URLSearchParams();
     if (innerRequest.query) {
       Object.entries(innerRequest.query).forEach(([key, value]) => {
-        url.searchParams.append(key, value);
+        searchParams.append(key, value);
       });
     }
+
+    const url = `${baseUrl}${innerRequest.path}?${searchParams.toString()}`;
 
     const method = innerRequest.method;
     const request = new Request(url, {

--- a/tests/edc-client.test.ts
+++ b/tests/edc-client.test.ts
@@ -80,4 +80,17 @@ describe("EdcConnectorClient", () => {
       });
     });
   });
+
+  describe("edcClient.inner.#fetch", () => {
+    it("accepts relative urls", async () => {
+      const edcClient = new EdcConnectorClient.Builder()
+        .apiToken("123456")
+        .defaultUrl("/defaultUrl")
+        .build();
+
+      await expect(edcClient.observability.checkHealth()).rejects.not.toThrow(
+        "Invalid URL",
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description
<!-- Describe the goal of the pull request in one or two sentences. -->
Up until now, `Addresses` were required to include the origin (e.g., `https://my.edc.example.com/api/check/health`), but it become impractical when we want to implement a UI with proxy on the same origin (e.g., `/api/check/health`).

This ability allow the URL to be relative, enabling the use case mentioned above.

### How to test it
<!-- List the steps necessary to test the content of the PR. -->
Added a test to ensure failure is coming from the HTTP request, and not from the URL construction. Since relative URLs work only in the browser, I wouldn't know how to test this without bringing in a new e2e setup (e.g., using playwright or cypress)

---

<!--

Pull requests are a chance to teach and learn: share the knowledge. With PRs, we
keep track of the features' history of a code-base and – indirectly – we write
documentation.

It is fundamental to ensure new joiners of future endeavors can easily read
through our code choices.

So let's share our learnings.

-->


## Approach
<!-- How does this change address the problem? -->
Rather then constructing the URL via `new URL(...)` and then adding query parameters to the instance, URL is simply a concatenation of two strings – the "baseUrl" (or relative path) and the resource path), appending at the end the query params added to a newly instance of `URLSearchParams`:

```ts
    const searchParams = new URLSearchParams();
    if (innerRequest.query) {
      Object.entries(innerRequest.query).forEach(([key, value]) => {
        searchParams.append(key, value);
      });
    }

    const url = `${baseUrl}${innerRequest.path}?${searchParams.toString()}`;
```
