### PR TITLE
feat: improve transpiled typings

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,37 +11,105 @@ export type EdcConnectorClientType<
   T extends Record<string, EdcController>,
 > = EdcConnectorClient & T;
 
+const apiTokenSymbol = Symbol("[#apiToken]");
+const addressesSymbol = Symbol("[#addressesToken]");
+const innerSymbol = Symbol("[#innerToken]");
+
+class Builder<T extends Record<string, EdcController> = {}> {
+  #instance = new EdcConnectorClient();
+
+  apiToken(apiToken: string): this {
+    this.#instance[apiTokenSymbol] = apiToken;
+    return this;
+  }
+
+  managementUrl(managementUrl: string): this {
+    this.#instance[addressesSymbol].management = managementUrl;
+    return this;
+  }
+
+  defaultUrl(defaultUrl: string): this {
+    this.#instance[addressesSymbol].default = defaultUrl;
+    return this;
+  }
+
+  protocolUrl(protocolUrl: string): this {
+    this.#instance[addressesSymbol].protocol = protocolUrl;
+    return this;
+  }
+
+  publicUrl(publicUrl: string): this {
+    this.#instance[addressesSymbol].public = publicUrl;
+    return this;
+  }
+
+  controlUrl(controlUrl: string): this {
+    this.#instance[addressesSymbol].control = controlUrl;
+    return this;
+  }
+
+  use<K extends string, C extends EdcController>(
+    key: K,
+    Controller: Class<C>,
+  ): Builder<T & Record<K, C>> {
+    Object.defineProperty(this.#instance, key, {
+      get() {
+        return new Controller(
+          this.inner,
+          this.createContext(
+            this.apiToken!,
+            this.addresses,
+          ),
+        );
+      },
+      enumerable: true,
+      configurable: false,
+    });
+
+    // SAFETY: we use `Object.defineProperty` above to extend the `EdcConnectorClient` instance.
+    return this as any;
+  }
+
+  build(): EdcConnectorClientType<
+    T
+  > {
+    return this.#instance as
+      & EdcConnectorClient
+      & T;
+  }
+}
+
 export class EdcConnectorClient {
-  #apiToken: string | undefined;
-  #addresses: Addresses = {};
-  #inner = new Inner();
+  [apiTokenSymbol]: string | undefined;
+  [addressesSymbol]: Addresses = {};
+  [innerSymbol] = new Inner();
 
   get management() {
     const context = new EdcConnectorClientContext(
-      this.#apiToken,
-      this.#addresses,
+      this[apiTokenSymbol],
+      this[addressesSymbol],
     );
-    return new ManagementController(this.#inner, context);
+    return new ManagementController(this[innerSymbol], context);
   }
 
   get observability() {
     const context = new EdcConnectorClientContext(
-      this.#apiToken,
-      this.#addresses,
+      this[apiTokenSymbol],
+      this[addressesSymbol],
     );
-    return new ObservabilityController(this.#inner, context);
+    return new ObservabilityController(this[innerSymbol], context);
   }
 
   get public() {
     const context = new EdcConnectorClientContext(
-      this.#apiToken,
-      this.#addresses,
+      this[apiTokenSymbol],
+      this[addressesSymbol],
     );
-    return new PublicController(this.#inner, context);
+    return new PublicController(this[innerSymbol], context);
   }
 
   get addresses() {
-    return this.#addresses;
+    return { ...this[addressesSymbol] };
   }
 
   createContext(
@@ -55,72 +123,5 @@ export class EdcConnectorClient {
     return version;
   }
 
-  static Builder = class Builder<
-    Controllers extends Record<
-      string,
-      EdcController
-    > = {},
-  > {
-    #instance = new EdcConnectorClient();
-
-    apiToken(apiToken: string): this {
-      this.#instance.#apiToken = apiToken;
-      return this;
-    }
-
-    managementUrl(managementUrl: string): this {
-      this.#instance.#addresses.management = managementUrl;
-      return this;
-    }
-
-    defaultUrl(defaultUrl: string): this {
-      this.#instance.#addresses.default = defaultUrl;
-      return this;
-    }
-
-    protocolUrl(protocolUrl: string): this {
-      this.#instance.#addresses.protocol = protocolUrl;
-      return this;
-    }
-
-    publicUrl(publicUrl: string): this {
-      this.#instance.#addresses.public = publicUrl;
-      return this;
-    }
-
-    controlUrl(controlUrl: string): this {
-      this.#instance.#addresses.control = controlUrl;
-      return this;
-    }
-
-    use<K extends string, C extends EdcController>(
-      key: K,
-      Controller: Class<C>,
-    ): Builder<Controllers & Record<K, C>> {
-      Object.defineProperty(this.#instance, key, {
-        get() {
-          return new Controller(
-            this.#inner,
-            this.createContext(
-              this.#apiToken!,
-              this.#addresses,
-            ),
-          );
-        },
-        enumerable: true,
-        configurable: false,
-      });
-
-      // SAFETY: we use `Object.defineProperty` above to extend the `EdcConnectorClient` instance.
-      return this as any;
-    }
-
-    build(): EdcConnectorClientType<
-      Controllers
-    > {
-      return this.#instance as
-        & EdcConnectorClient
-        & Controllers;
-    }
-  };
+  static Builder = Builder;
 }


### PR DESCRIPTION
## Description
<!-- Describe the goal of the pull request in one or two sentences. -->
The transpiled typings output looks way better when extracting the Builder declaration from static declaration to its own method.

I encountered this issue when playing around with some `EdcController` - I discovered that, even though the builder should return `this` for each of its methods (except the `use` one), the downstream library is always receive `any` instead of the correct builder type.

### How to test it
<!-- List the steps necessary to test the content of the PR. -->
Everything runs as expected


---

<!--

Pull requests are a chance to teach and learn: share the knowledge. With PRs, we
keep track of the features' history of a code-base and – indirectly – we write
documentation.

It is fundamental to ensure new joiners of future endeavors can easily read
through our code choices.

So let's share our learnings.

-->


## Approach
<!-- How does this change address the problem? -->

Instead of declaring the `Builder` class directly as a static property of `EdcConnectorClient`, the former class is declared at the top level.

This change is not a breaking one, because the `Builder` is later added as a static property.
While this refactor looks a long way to get the same functional results, it meaningfully increase the ergonomics for implementors.

The challenge with this, is that it's not possible for the `Builder` class to access private properties anymore (e.g., `#instance.#apiKey`). To tackle this, I opted for using `Symbol`, which creates a unique symbol for defining private class properties.
This works perfectly because `Symbol("test") !== Symbol("test")`.

