### PR TITLE
fix: remove duplicate release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           generateReleaseNotes: true
-          tag: ${{ inputs.version }}
+          tag: v${{ inputs.version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           makeLatest: true
           removeArtifacts: true


### PR DESCRIPTION
## Description
This pr fixes the issue where we have duplicate release tags (e.g. v0.8.0 and 0.8.0)