### PR TITLE
build: upgrade gradle to 9

### DIFF
--- a/connector/Dockerfile
+++ b/connector/Dockerfile
@@ -1,8 +1,11 @@
-FROM gradle:8.8-jdk17 AS build
+FROM gradle:9-jdk21 AS build
 
-COPY --chown=gradle:gradle . /home/gradle/project/
 WORKDIR /home/gradle/project/
-RUN gradle build --no-daemon
+
+COPY --chown=gradle:gradle . ./
+
+RUN --mount=type=cache,target=/home/gradle/.gradle/caches \
+    gradle build --no-daemon
 
 FROM eclipse-temurin:21
 

--- a/connector/build.gradle.kts
+++ b/connector/build.gradle.kts
@@ -23,8 +23,9 @@ application {
     mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
 }
 
-tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+tasks.shadowJar {
     dependsOn("distTar", "distZip")
     mergeServiceFiles()
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     archiveFileName.set("connector.jar")
 }

--- a/connector/gradle/libs.versions.toml
+++ b/connector/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ format.version = "1.1"
 
 [versions]
 edc = "0.14.1"
-shadow = "8.1.1"
+shadow = "9.2.2"
 
 [libraries]
 edc-api-observability = { module = "org.eclipse.edc:api-observability", version.ref = "edc" }
@@ -40,4 +40,4 @@ edc-crawler-spi = {module = "org.eclipse.edc:crawler-spi", version.ref = "edc"}
 edc-dataplane-public-api-v2 = {module = "org.eclipse.edc:data-plane-public-api-v2", version.ref = "edc"}
 
 [plugins]
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
### What
Updates gradle build test image to 9 (with jdk21)
Updates shadow plugin to the latest version (supporting gradle 9)
Set gradle caches (don't know if that really works but looks faster on my machine :shrug: )

