### PR TITLE
Make PolicyInput.profiles optional to align with EDC 0.15.x behavior

### DIFF
--- a/src/entities/policy/policy.ts
+++ b/src/entities/policy/policy.ts
@@ -17,7 +17,7 @@ export interface PolicyInput {
   permission?: Permission[];
   prohibition?: Prohibition[];
   target?: string;
-  profiles: string[];
+  profiles?: string[];
 }
 
 export class Policy extends JsonLdObject {


### PR DESCRIPTION
When using the Eclipse EDC connector versions 0.15.0 and 0.15.1, catalog responses and
policy handling may omit the profiles` attribute or require it to be null rather than
an empty array.

Having "profiles" as a mandatory field in PolicyInput causes TypeScript incompatibilities
when consuming real catalog data and building policies programmatically.

This change makes "profiles" optional to better reflect actual EDC behavior and improve
compatibility with current connector versions.

Note: the Eclipse EDC DataDashboard should also be adapted to send null insteadof "[]" when no profiles are present.

## Description
<!-- Describe the goal of the pull request in one or two sentences. -->

### How to test it
<!-- List the steps necessary to test the content of the PR. -->


---

<!--

Pull requests are a chance to teach and learn: share the knowledge. With PRs, we
keep track of the features' history of a code-base and – indirectly – we write
documentation.

It is fundamental to ensure new joiners of future endeavors can easily read
through our code choices.

So let's share our learnings.

-->


## Approach
<!-- How does this change address the problem? -->

### Open Questions and Pre-Merge TODOs
<!-- Optional - remove if not necessary

Provide a list of tasks/doubts to clarify if the pull request is still a _draft_ (a.k.a. not ready for review).

- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- Optional - remove if not necessary

Describe the research stage.

Links to blog posts, patterns, libraries or add-ons used to solve this problem.

Try adding as reference in support of your learnings.
Use links and footnotes (https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/).
-->
