### PR TITLE
chore: replace npm token with npm trusted publisher in github action

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,6 +16,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -57,5 +61,3 @@ jobs:
             echo "Publishing as latest (stable release)"
             npm publish --access=public --tag latest
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description
Long living npm tokens are no [longer supported](https://github.blog/changelog/2025-09-29-strengthening-npm-security-important-changes-to-authentication-and-token-management/#whats-changing) instead npm recommends using [npm trusted publisher](https://docs.npmjs.com/trusted-publishers). The setup on the think-it account has already been taken care of.