### PR TITLE
Revert "Prepare release 0.9.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@think-it-labs/edc-connector-client",
-  "version": "0.9.1",
+  "version": "v0.9.1",
   "description": "EDC Connector HTTP client",
   "private": false,
   "homepage": "https://github.com/Think-iT-Labs/edc-connector-client",


### PR DESCRIPTION
This reverts commit 87821eba038e931074cbe1a8fcd056cce4a65a38.

It was causing the release workflow to fail.