### PR TITLE
feat: support Tractus-X authentication JSON-LD context

### DIFF
--- a/src/entities/jsonld/contexts/tractusx-auth-v1.json
+++ b/src/entities/jsonld/contexts/tractusx-auth-v1.json
@@ -1,0 +1,12 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "tx-auth": "https://w3id.org/tractusx/auth/",
+    "refreshToken": "tx-auth:refreshToken",
+    "refreshEndpoint": "tx-auth:refreshEndpoint",
+    "refreshAudience": "tx-auth:refreshAudience",
+    "audience": "tx-auth:audience",
+    "expiresIn": "tx-auth:expiresIn"
+  }
+}

--- a/src/entities/jsonld/custom-loader.ts
+++ b/src/entities/jsonld/custom-loader.ts
@@ -2,6 +2,7 @@ import jsonld from "jsonld";
 import dspace2025Data from "./contexts/dspace-2025.json";
 import edcDspaceData from "./contexts/edc-dspace.json";
 import odrlProfileData from "./contexts/odrl-profile.json";
+import tractusxAuthData from "./contexts/tractusx-auth-v1.json";
 import { MANAGEMENT_V2_CONTEXT } from "../context";
 import managementV2Data from "./contexts/management-v2.json";
 
@@ -9,6 +10,7 @@ const JSONLD_CONTEXTS: Record<string, object> = {
   "https://w3id.org/edc/dspace/v0.0.1": edcDspaceData,
   "https://w3id.org/dspace/2025/1/context.jsonld": dspace2025Data,
   "https://w3id.org/dspace/2025/1/odrl-profile.jsonld": odrlProfileData,
+  "https://w3id.org/tractusx/auth/v1.0.0": tractusxAuthData,
   [MANAGEMENT_V2_CONTEXT]: managementV2Data,
 };
 

--- a/tests/controllers/management-tests/catalog-response.test.ts
+++ b/tests/controllers/management-tests/catalog-response.test.ts
@@ -1,0 +1,66 @@
+import nock = require("nock");
+import { EdcConnectorClient } from "../../../src";
+
+const catalogResponse = {
+  "@id": "catalog",
+  "@type": "Catalog",
+  dataset: [
+    {
+      "@id": "asset",
+      "@type": "Dataset",
+      hasPolicy: [
+        {
+          "@id": "offer",
+          "@type": "Offer",
+        },
+      ],
+    },
+  ],
+  participantId: "did:web:identityhub.example:user:participant-a-01",
+  "@context": [
+    "https://w3id.org/tractusx/auth/v1.0.0",
+    "https://w3id.org/dspace/2025/1/context.jsonld",
+    "https://w3id.org/edc/dspace/v0.0.1",
+    {
+      "fx-policy": "https://w3id.org/factoryx/policy/v1.0/",
+    },
+  ],
+};
+
+describe("CatalogController catalog response compatibility", () => {
+  const managementUrl = "http://connector.example/management";
+
+  beforeEach(() => {
+    if (!nock.isActive()) {
+      nock.activate();
+    }
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.restore();
+  });
+
+  it("parses catalogs containing the Tractus-X authentication context", async () => {
+    const request = nock(managementUrl)
+      .post("/v3/catalog/request")
+      .reply(200, catalogResponse);
+
+    const client = new EdcConnectorClient.Builder()
+      .apiToken("test-token")
+      .managementUrl(managementUrl)
+      .build();
+
+    const catalog = await client.management.catalog.request({
+      counterPartyAddress: "https://provider.example/api/v1/dsp/2025-1",
+      counterPartyId: "did:web:provider.example",
+    });
+
+    expect(catalog.participantId).toBe(
+      "did:web:identityhub.example:user:participant-a-01",
+    );
+    expect(catalog.datasets[0].id).toBe("asset");
+    expect(catalog.datasets[0].offers[0].id).toBe("offer");
+    expect(request.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description
Add support for catalog responses that reference the Tractus-X authentication JSON-LD context used by DSP 2025-1 connectors.

### How to test it

Run:
```shell
yarn install --frozen-lockfile --production=false
yarn test tests/controllers/management-tests/catalog-response.test.ts
```

#### Example

Catalog response example which currently does not parse for me in EDC Data Dashboard

<details>

<summary>JSON example</summary>

```json
{
  "@id": "541ad175-1964-40ae-8229-6d7bc1d7a589",
  "@type": "Catalog",
  "dataset": [
    {
      "@id": "basyx",
      "@type": "Dataset",
      "hasPolicy": [
        {
          "@id": "c3RhbmRhcmQtanNvbi10ZXN0LWNvbnRyYWN0LWV4YW1wbGUtcGFydGljaXBhbnQtZGVmaW5pdGlvbg==:YmFzeXg=:MjQ2ZjkyYzEtNDFjNy00ZmY4LWEzOWQtNGNkZGI2ZWU2ZGZh",
          "@type": "Offer",
          "permission": [
            {
              "action": "use"
            }
          ]
        }
      ],
      "distribution": [
        {
          "@type": "Distribution",
          "format": "AzureStorage-PUSH",
          "accessService": {
            "@id": "2e54a817-42da-49a7-913e-ccd74265837a",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        },
        {
          "@type": "Distribution",
          "format": "HttpData-PULL",
          "accessService": {
            "@id": "59e3da62-0be2-4128-8544-e65e419ad8e8",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        },
        {
          "@type": "Distribution",
          "format": "HttpData-PUSH",
          "accessService": {
            "@id": "9fe4a72d-0a29-47e1-8761-cc5e6aaeeb5d",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        },
        {
          "@type": "Distribution",
          "format": "AmazonS3-PUSH",
          "accessService": {
            "@id": "e01b3e38-87b7-439b-9f1b-fb11e7208033",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        },
        {
          "@type": "Distribution",
          "format": "HttpTlsData-PUSH",
          "accessService": {
            "@id": "cf1a6712-8115-4343-844d-f9eb42fda7ed",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        },
        {
          "@type": "Distribution",
          "format": "ProxyHttpData-PULL",
          "accessService": {
            "@id": "a3512200-f391-4979-90ea-633c7230e545",
            "@type": "DataService",
            "endpointDescription": "dspace:connector",
            "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
          }
        }
      ],
      "dct:type": {
        "@id": "https://admin-shell.io/aas/API/3/0/SubmodelRepositoryServiceSpecification/SSP-002"
      },
      "id": "basyx"
    }
  ],
  "service": [
    {
      "@id": "a26aea91-05ed-4cbb-af77-1da01a6088c1",
      "@type": "DataService",
      "endpointDescription": "dspace:connector",
      "endpointURL": "https://control.example.com/api/v1/dsp/2025-1"
    }
  ],
  "participantId": "did:web:identityhub.example.com:user:example-participant",
  "@context": [
    "https://w3id.org/tractusx/auth/v1.0.0",
    "https://w3id.org/dspace/2025/1/context.jsonld",
    "https://w3id.org/edc/dspace/v0.0.1"
  ]
}
```

</details>

## Approach
The content of [`tractusx-auth-v1.json`](https://eclipse-tractusx.github.io/tractusx-edc/context/tx-auth-v1.jsonld) which should resolve via `https://w3id.org/tractusx/auth/v1.0.0` is added to `jsonld/contexts`

Closes #638 