### PR TITLE
feat: API authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ for doing that it can be instantiated through the `EdcConnectorClient.Builder`
 import { EdcConnectorClient } from "@think-it-labs/edc-connector-client"
 
 const client = new EdcConnectorClient.Builder()
-  .apiToken("123456")
+  .authorization("X-Api-Key", "123456")
   .managementUrl("https://edc.think-it.io/management")
   .build();
 ```
+
+The `authorization(key, value)` method sets the HTTP header used to authenticate requests (e.g. `"X-Api-Key"`, `"Authorization"`).
+
+> **Note** `apiToken(token)` is deprecated. It is equivalent to calling `.authorization("X-Api-Key", token)`.
 
 At this point the calls can be made against the specified connector:
 ```ts
@@ -95,12 +99,18 @@ const client = new EdcConnectorClient();
 ```
 
 Context objects can be created with a `createContext` call:
+
 ```ts
-const context = client.createContext("123456", {
-  default: "https://edc.think-it.io/api",
-  management: "https://edc.think-it.io/management",
-  protocol: "https://edc.think-it.io/protocol",
-  control: "https://edc.think-it.io/control",
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client";
+
+const context = EdcConnectorClient.createContext({
+  authorization: { "X-Api-Key": "123456" },
+  addresses: {
+    default: "https://edc.think-it.io/api",
+    management: "https://edc.think-it.io/management",
+    protocol: "https://edc.think-it.io/protocol",
+    control: "https://edc.think-it.io/control",
+  },
 });
 ```
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ export type ContextInput = {
   protocolVersion?: string;
   managementApiVersion?: string;
   identityApiVersion?: string;
+  authorization?: Record<string, string> | undefined;
 };
 
 const apiTokenSymbol = Symbol("[#apiToken]");
@@ -27,6 +28,7 @@ const innerSymbol = Symbol("[#innerToken]");
 const protocolVersionSymbol = Symbol("[#protocolVersion]");
 const managementApiVersionSymbol = Symbol("[#managementApiVersion]");
 const identityApiVersionSymbol = Symbol("[#identityApiVersion]");
+const authorization = Symbol("[#authorization]");
 
 class Builder<T extends Record<string, EdcController> = {}> {
   #instance = new EdcConnectorClient();
@@ -35,9 +37,18 @@ class Builder<T extends Record<string, EdcController> = {}> {
   [protocolVersionSymbol]?: string;
   [managementApiVersionSymbol]?: string;
   [identityApiVersionSymbol]?: string;
+  [authorization]?: Record<string, string>;
 
+  /**
+   * @deprecated use authorization instead
+   */
   apiToken(apiToken: string): this {
-    this[apiTokenSymbol] = apiToken;
+    this.authorization("X-Api-Key", apiToken);
+    return this;
+  }
+
+  authorization(key: string, value: string): this {
+    this[authorization] = { [key]: value };
     return this;
   }
 
@@ -110,6 +121,7 @@ class Builder<T extends Record<string, EdcController> = {}> {
   build(): EdcConnectorClientType<T> {
     this.#instance.context = EdcConnectorClient.createContext({
       token: this[apiTokenSymbol],
+      authorization: this[authorization],
       addresses: this[addressesSymbol],
       protocolVersion: this[protocolVersionSymbol],
       managementApiVersion: this[managementApiVersionSymbol],
@@ -152,34 +164,23 @@ export class EdcConnectorClient {
     return this.context.addresses;
   }
 
-  /**
-   * @deprecated
-   */
-  createContext(
-    token: string,
-    addresses: Addresses,
-    protocolVersion?: string,
-  ): EdcConnectorClientContext {
-    return new EdcConnectorClientContext(token, addresses, protocolVersion);
-  }
-
   static createContext(
     {
-      token,
       addresses,
       protocolVersion,
       managementApiVersion,
       identityApiVersion,
+      authorization,
     }: ContextInput = {
       addresses: {},
     },
   ): EdcConnectorClientContext {
     return new EdcConnectorClientContext(
-      token,
       addresses,
       protocolVersion,
       managementApiVersion,
       identityApiVersion,
+      authorization,
     );
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -5,20 +5,20 @@ import {
 } from "./entities";
 
 export class EdcConnectorClientContext implements Addresses {
-  #apiToken: string | undefined;
+  #authorization: Record<string, string> | undefined;
   #addresses: Addresses;
   #protocolVersion: string;
   #managementApiVersion: string;
   #identityApiVersion: string;
 
   constructor(
-    apiToken: string | undefined,
     addresses: Addresses,
     protocolVersion = "dataspace-protocol-http:2025-1",
     managementApiVersion = DEFAULT_MANAGEMENT_API_VERSION,
     identityApiVersion = DEFAULT_IDENTITY_API_VERSION,
+    authorization?: Record<string, string>,
   ) {
-    this.#apiToken = apiToken;
+    this.#authorization = authorization;
     this.#addresses = addresses;
     this.#protocolVersion = protocolVersion;
     this.#managementApiVersion = managementApiVersion;
@@ -63,8 +63,8 @@ export class EdcConnectorClientContext implements Addresses {
     );
   }
 
-  get apiToken(): string | undefined {
-    return this.#apiToken;
+  get authorization(): Record<string, string> | undefined {
+    return this.#authorization;
   }
 
   get managementApiVersion(): string {

--- a/src/controllers/federated-catalog-controller.ts
+++ b/src/controllers/federated-catalog-controller.ts
@@ -27,7 +27,7 @@ export class FederatedCatalogController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body,
       })
       .then((body) => expandArray(body, () => new Catalog()));

--- a/src/controllers/identity-controllers/dids-controller.ts
+++ b/src/controllers/identity-controllers/dids-controller.ts
@@ -17,7 +17,7 @@ export class DIDsController extends IdentityBaseController {
     return this.inner.request<DIDDocument[]>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       query,
     });
   }

--- a/src/controllers/identity-controllers/keypairs-controller.ts
+++ b/src/controllers/identity-controllers/keypairs-controller.ts
@@ -17,7 +17,7 @@ export class KeyPairsController extends IdentityBaseController {
     return this.inner.request<KeyPair[]>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       query,
     });
   }

--- a/src/controllers/identity-controllers/participant-controllers/participant-controller.ts
+++ b/src/controllers/identity-controllers/participant-controllers/participant-controller.ts
@@ -24,7 +24,7 @@ export class ParticipantController extends IdentityBaseController {
     return this.inner.request<string>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -37,7 +37,7 @@ export class ParticipantController extends IdentityBaseController {
         path: `${this.getBasePath(actualContext)}/roles`,
         method: "PUT",
         body: roles,
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       },
     );
   }
@@ -59,7 +59,7 @@ export class ParticipantController extends IdentityBaseController {
       method: "POST",
       query: { isActive: String(isActive) },
       body,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -79,7 +79,7 @@ export class ParticipantController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/token`,
       method: "POST",
       body,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 

--- a/src/controllers/identity-controllers/participant-controllers/participant-dids-controller.ts
+++ b/src/controllers/identity-controllers/participant-controllers/participant-dids-controller.ts
@@ -22,7 +22,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/publish`,
       method: "POST",
       body: { did },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -36,7 +36,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/query`,
       method: "POST",
       body: query,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -48,7 +48,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/state`,
       method: "POST",
       body: { did },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -60,7 +60,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/unpublish`,
       method: "POST",
       body: { did },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -80,7 +80,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
         autoPublish: String(autoPublish),
       },
       body: service,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -105,7 +105,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/${did}/endpoints`,
       method: "DELETE",
       query,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -123,7 +123,7 @@ export class ParticipantDIDsController extends IdentityBaseController {
       query: {
         autoPublish: String(autoPublish),
       },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 }

--- a/src/controllers/identity-controllers/participant-controllers/participant-keypairs-controller.ts
+++ b/src/controllers/identity-controllers/participant-controllers/participant-keypairs-controller.ts
@@ -18,7 +18,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
     return this.inner.request<KeyPair>(actualContext.identity, {
       path: `${this.getBasePath(actualContext)}/${keyPairId}`,
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -28,7 +28,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
     return this.inner.request<KeyPair[]>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -46,7 +46,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
       query: {
         makeDefault: String(makeDefault),
       },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -56,7 +56,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
     return this.inner.request<void>(actualContext.identity, {
       path: `${this.getBasePath(actualContext)}/${keyPairId}/activate`,
       method: "POST",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -71,7 +71,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
       path: `${this.getBasePath(actualContext)}/${keyPairId}/revoke`,
       method: "POST",
       body: newKeyDescriptor,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -90,7 +90,7 @@ export class ParticipantKeyPairContoller extends IdentityBaseController {
       query: {
         duration: String(duration),
       },
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 }

--- a/src/controllers/identity-controllers/participant-controllers/participant-verifiable-credentials-controller.ts
+++ b/src/controllers/identity-controllers/participant-controllers/participant-verifiable-credentials-controller.ts
@@ -33,7 +33,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
         path: this.getBasePath(actualContext),
         method: "GET",
         query,
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       },
     );
   }
@@ -48,7 +48,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
       path: this.getBasePath(actualContext),
       method: "PUT",
       body: input,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -62,7 +62,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
       path: this.getBasePath(actualContext),
       method: "POST",
       body: input,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -76,7 +76,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
       path: `${this.getBasePath(actualContext)}/request`,
       method: "POST",
       body: input,
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -91,7 +91,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
       {
         path: `${this.getBasePath(actualContext)}/request/${issuerPid}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       },
     );
   }
@@ -107,7 +107,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
       {
         path: `${this.getBasePath(actualContext)}/${credentialId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       },
     );
   }
@@ -121,7 +121,7 @@ export class ParticipantVerifiableCredentialsController extends IdentityBaseCont
     return this.inner.request<string>(actualContext.identity, {
       path: `${this.getBasePath(actualContext)}/${credentialId}`,
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 }

--- a/src/controllers/identity-controllers/participants-controller.ts
+++ b/src/controllers/identity-controllers/participants-controller.ts
@@ -17,7 +17,7 @@ export class ParticipantsController extends IdentityBaseController {
     return this.inner.request<Participant[]>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       query,
     });
   }
@@ -32,7 +32,7 @@ export class ParticipantsController extends IdentityBaseController {
     }>(actualContext.identity, {
       path: this.getBasePath(actualContext),
       method: "POST",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: input,
     });
   }
@@ -43,7 +43,7 @@ export class ParticipantsController extends IdentityBaseController {
     return this.inner.request<Participant>(actualContext.identity, {
       path: `${this.getBasePath(actualContext)}/${participantId}`,
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 }

--- a/src/controllers/identity-controllers/verifiable-credentials-controller.ts
+++ b/src/controllers/identity-controllers/verifiable-credentials-controller.ts
@@ -19,7 +19,7 @@ export class VerifiableCredentialsController extends IdentityBaseController {
       {
         path: this.getBasePath(actualContext),
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         query,
       },
     );

--- a/src/controllers/management-controllers/asset-controller.ts
+++ b/src/controllers/management-controllers/asset-controller.ts
@@ -26,7 +26,7 @@ export class AssetController extends ManagementBaseController {
       .request(actualContext.management, {
         path: this.management.getBasePath(actualContext),
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...input,
           "@context": this.management.getContextUrl(actualContext),
@@ -44,7 +44,7 @@ export class AssetController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${assetId}`,
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -58,7 +58,7 @@ export class AssetController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${assetId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new Asset()));
   }
@@ -72,7 +72,7 @@ export class AssetController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: this.management.getBasePath(actualContext),
       method: "PUT",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: {
         ...input,
         "@context": this.management.getContextUrl(actualContext),
@@ -90,7 +90,7 @@ export class AssetController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...query,
           "@context": this.management.getContextUrl(actualContext),

--- a/src/controllers/management-controllers/catalog-controller.ts
+++ b/src/controllers/management-controllers/catalog-controller.ts
@@ -24,7 +24,7 @@ export class CatalogController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           "@context": this.management.getContextUrl(actualContext),
           "@type": "CatalogRequest",
@@ -45,7 +45,7 @@ export class CatalogController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/dataset/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           "@context": this.management.getContextUrl(actualContext),
           "@type": "DatasetRequest",

--- a/src/controllers/management-controllers/catalogs-controller.ts
+++ b/src/controllers/management-controllers/catalogs-controller.ts
@@ -27,7 +27,7 @@ export class CatalogsController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body,
       })
       .then((body) => expandArray(body, () => new Catalog()));

--- a/src/controllers/management-controllers/contract-agreement-controller.ts
+++ b/src/controllers/management-controllers/contract-agreement-controller.ts
@@ -30,7 +30,7 @@ export class ContractAgreementController {
       .request(actualContext.management, {
         path: `${this.#basePath}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body:
           Object.keys(query).length === 0
             ? null
@@ -52,7 +52,7 @@ export class ContractAgreementController {
       .request(actualContext.management, {
         path: `${this.#basePath}/${agreementId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractAgreement()));
   }
@@ -67,7 +67,7 @@ export class ContractAgreementController {
       .request(actualContext.management, {
         path: `${this.#basePath}/${agreementId}/negotiation`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractNegotiation()));
   }

--- a/src/controllers/management-controllers/contract-defintion-controller.ts
+++ b/src/controllers/management-controllers/contract-defintion-controller.ts
@@ -26,7 +26,7 @@ export class ContractDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: this.management.getBasePath(actualContext),
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...input,
           "@context": this.management.getContextUrl(actualContext),
@@ -44,7 +44,7 @@ export class ContractDefinitionController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${contractDefinitionId}`,
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -58,7 +58,7 @@ export class ContractDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${contractDefinitionId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractDefinition()));
   }
@@ -73,7 +73,7 @@ export class ContractDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...query,
           "@context": this.management.getContextUrl(actualContext),
@@ -91,7 +91,7 @@ export class ContractDefinitionController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: this.management.getBasePath(actualContext),
       method: "PUT",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: {
         ...input,
         "@context": this.management.getContextUrl(actualContext),

--- a/src/controllers/management-controllers/contract-negotiation-controller.ts
+++ b/src/controllers/management-controllers/contract-negotiation-controller.ts
@@ -28,7 +28,7 @@ export class ContractNegotiationController extends ManagementBaseController {
       .request(actualContext.management, {
         path: this.management.getBasePath(actualContext),
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           "@context": this.management.getContextUrl(actualContext),
           "@type": "ContractRequest",
@@ -49,7 +49,7 @@ export class ContractNegotiationController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body:
           Object.keys(query).length === 0
             ? null
@@ -71,7 +71,7 @@ export class ContractNegotiationController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${negotiationId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractNegotiation()));
   }
@@ -86,7 +86,7 @@ export class ContractNegotiationController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${negotiationId}/state`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractNegotiationState()));
   }
@@ -101,7 +101,7 @@ export class ContractNegotiationController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${negotiationId}/terminate`,
       method: "POST",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: {
         "@context": this.management.getContextUrl(actualContext),
         ...(actualContext.managementApiVersion === "v4"
@@ -123,7 +123,7 @@ export class ContractNegotiationController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${negotiationId}/agreement`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new ContractAgreement()));
   }

--- a/src/controllers/management-controllers/dataplane-controller.ts
+++ b/src/controllers/management-controllers/dataplane-controller.ts
@@ -22,7 +22,7 @@ export class DataplaneController {
       .request(actualContext.management, {
         path: this.#basePath,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expandArray(body, () => new Dataplane()));
   }

--- a/src/controllers/management-controllers/edr-controller.ts
+++ b/src/controllers/management-controllers/edr-controller.ts
@@ -30,7 +30,7 @@ export class EdrController {
       .request(actualContext.management, {
         path: `${this.#basePath}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body:
           Object.keys(query).length === 0
             ? null
@@ -51,7 +51,7 @@ export class EdrController {
     return this.#inner.request(actualContext.management, {
       path: `${this.#basePath}/${edrId}`,
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -65,7 +65,7 @@ export class EdrController {
       .request(actualContext.management, {
         path: `${this.#basePath}/${edrId}/dataaddress`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new JsonLdObject()));
   }

--- a/src/controllers/management-controllers/policy-defintion-controller.ts
+++ b/src/controllers/management-controllers/policy-defintion-controller.ts
@@ -26,7 +26,7 @@ export class PolicyDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: this.management.getBasePath(actualContext),
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...input,
           "@context": this.management.getContextUrl(actualContext),
@@ -45,7 +45,7 @@ export class PolicyDefinitionController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${policyId}`,
       method: "PUT",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: {
         ...input,
         "@context": this.management.getContextUrl(actualContext),
@@ -62,7 +62,7 @@ export class PolicyDefinitionController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${policyId}`,
       method: "DELETE",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -76,7 +76,7 @@ export class PolicyDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${policyId}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new PolicyDefinition()));
   }
@@ -91,7 +91,7 @@ export class PolicyDefinitionController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           ...query,
           "@context": this.management.getContextUrl(actualContext),

--- a/src/controllers/management-controllers/secret-controller.ts
+++ b/src/controllers/management-controllers/secret-controller.ts
@@ -29,7 +29,7 @@ export class SecretController {
     return this.#inner.request(actualContext.management, {
         path: this.#basePath,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body
       });
   }
@@ -44,7 +44,7 @@ export class SecretController {
       .request(actualContext.management, {
         path: `${this.#basePath}/${id}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new Secret()));
   }
@@ -60,7 +60,7 @@ export class SecretController {
     return this.#inner.request(actualContext.management, {
       path: this.#basePath,
       method: "PUT",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body,
     });
   }
@@ -71,7 +71,7 @@ export class SecretController {
     return this.#inner.request(actualContext.management, {
         path: `${this.#basePath}/${id}`,
         method: "DELETE",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       });
   }
 

--- a/src/controllers/management-controllers/transfer-process-controller.ts
+++ b/src/controllers/management-controllers/transfer-process-controller.ts
@@ -27,7 +27,7 @@ export class TransferProcessController extends ManagementBaseController {
       .request(actualContext.management, {
         path: this.management.getBasePath(actualContext),
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body: {
           "@context": this.management.getContextUrl(actualContext),
           "@type": "TransferRequest",
@@ -48,7 +48,7 @@ export class TransferProcessController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${id}`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new TransferProcess()));
   }
@@ -63,7 +63,7 @@ export class TransferProcessController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/request`,
         method: "POST",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
         body:
           Object.keys(query).length === 0
             ? null
@@ -85,7 +85,7 @@ export class TransferProcessController extends ManagementBaseController {
       .request(actualContext.management, {
         path: `${this.management.getBasePath(actualContext)}/${transferProcessId}/state`,
         method: "GET",
-        apiToken: actualContext.apiToken,
+        authorization: actualContext.authorization,
       })
       .then((body) => expand(body, () => new TransferProcessState()));
   }
@@ -100,7 +100,7 @@ export class TransferProcessController extends ManagementBaseController {
     return this.inner.request(actualContext.management, {
       path: `${this.management.getBasePath(actualContext)}/${id}/terminate`,
       method: "POST",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
       body: {
         "@context": this.management.getContextUrl(actualContext),
         "@type": "TerminateTransfer",

--- a/src/controllers/observability-controller.ts
+++ b/src/controllers/observability-controller.ts
@@ -11,7 +11,7 @@ export class ObservabilityController extends EdcController {
     return this.inner.request(actualContext.default, {
       path: "/check/health",
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -23,7 +23,7 @@ export class ObservabilityController extends EdcController {
     return this.inner.request(actualContext.default, {
       path: "/check/liveness",
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -35,7 +35,7 @@ export class ObservabilityController extends EdcController {
     return this.inner.request(actualContext.default, {
       path: "/check/readiness",
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 
@@ -47,7 +47,7 @@ export class ObservabilityController extends EdcController {
     return this.inner.request(actualContext.default, {
       path: "/check/startup",
       method: "GET",
-      apiToken: actualContext.apiToken,
+      authorization: actualContext.authorization,
     });
   }
 }

--- a/src/inner.ts
+++ b/src/inner.ts
@@ -5,13 +5,8 @@ interface InnerRequest {
   method: "DELETE" | "GET" | "POST" | "PUT" | "PATCH";
   query?: Record<string, string>;
   body?: unknown;
-  apiToken?: string;
-  headers?: Record<string, string | undefined>;
-}
-
-interface InnerStream extends InnerRequest {
-  body?: undefined;
-  apiToken?: undefined;
+  authorization?: Record<string, string> | undefined;
+  headers?: Record<string, string>;
 }
 
 export class Inner {
@@ -26,19 +21,6 @@ export class Inner {
     }
 
     return response.json();
-  }
-
-  async stream(baseUrl: string, innerRequest: InnerStream): Promise<Response> {
-    const response = await this.#fetch(baseUrl, innerRequest);
-
-    if (response.status === 204 || !response.body) {
-      throw new EdcConnectorClientError(
-        EdcConnectorClientErrorType.Unreachable,
-        "response is never empty",
-      );
-    }
-
-    return response;
   }
 
   async #fetch(baseUrl: string, innerRequest: InnerRequest): Promise<Response> {
@@ -56,7 +38,7 @@ export class Inner {
       method,
       headers: {
         ...innerRequest.headers,
-        "X-Api-Key": innerRequest.apiToken ?? "",
+        ...(innerRequest.authorization ?? {}),
       },
       body: innerRequest.body ? JSON.stringify(innerRequest.body) : undefined,
     });
@@ -72,37 +54,29 @@ export class Inner {
 
       switch (response.status) {
         case 400: {
-          const error = new EdcConnectorClientError(
+          throw new EdcConnectorClientError(
             EdcConnectorClientErrorType.BadRequest,
             "request was malformed: " + errorMessage,
           );
-
-          throw error;
         }
         case 404: {
-          const error = new EdcConnectorClientError(
+          throw new EdcConnectorClientError(
             EdcConnectorClientErrorType.NotFound,
             "resource not found: " + errorMessage,
           );
-
-          throw error;
         }
         case 409: {
-          const error = new EdcConnectorClientError(
+          throw new EdcConnectorClientError(
             EdcConnectorClientErrorType.Duplicate,
             "duplicated resource: " + errorMessage,
           );
-
-          throw error;
         }
 
         case 502: {
-          const error = new EdcConnectorClientError(
+          throw new EdcConnectorClientError(
             EdcConnectorClientErrorType.BadGateway,
             "Bad Gateway: " + errorMessage,
           );
-
-          throw error;
         }
 
         default: {

--- a/tests/edc-client.test.ts
+++ b/tests/edc-client.test.ts
@@ -1,9 +1,9 @@
 import {
+  Addresses,
   EdcConnectorClient,
   EdcConnectorClientContext,
   EdcController,
 } from "../src";
-import { Addresses } from "../src";
 import { Inner } from "../src/inner";
 
 describe("EdcConnectorClient", () => {
@@ -19,8 +19,6 @@ describe("EdcConnectorClient", () => {
 
   describe("edcClient.createContext", () => {
     it("creates a new EdcConnectorClientContext", async () => {
-      // given
-      const apiToken = "123456";
       const addresses: Addresses = {
         default: "http://localhost:19191",
         management: "http://localhost:19193",
@@ -29,32 +27,28 @@ describe("EdcConnectorClient", () => {
       };
       const protocol = "protocol";
 
-      // when
       const context = EdcConnectorClient.createContext({
-        token: apiToken,
         addresses,
         protocolVersion: protocol,
+        authorization: { "Authorization": "token" },
       });
 
-      // then
       expect(context).toBeInstanceOf(EdcConnectorClientContext);
-      expect(context.apiToken).toBe(apiToken);
       expect(context.default).toBe(addresses.default);
       expect(context.management).toBe(addresses.management);
       expect(context.protocol).toBe(addresses.protocol);
       expect(context.control).toBe(addresses.control);
       expect(context.protocolVersion).toBe(protocol);
+      expect(context.authorization).toStrictEqual({ "Authorization": "token" });
     });
 
     it("creates context correctly with builder.build", () => {
-      const apiToken = "123456";
       const defaultUrl = "http://localhost:19191";
       const managementUrl = "http://localhost:19193";
       const protocolUrl = "http://localhost:19194";
       const protocol = "protocol";
 
       const client = new EdcConnectorClient.Builder()
-        .apiToken(apiToken)
         .managementUrl(managementUrl)
         .defaultUrl(defaultUrl)
         .protocolUrl(protocolUrl)
@@ -62,7 +56,6 @@ describe("EdcConnectorClient", () => {
         .build();
 
       expect(client.context).toBeInstanceOf(EdcConnectorClientContext);
-      expect(client.context.apiToken).toBe(apiToken);
       expect(client.context.default).toBe(defaultUrl);
       expect(client.context.management).toBe(managementUrl);
       expect(client.context.protocol).toBe(protocolUrl);
@@ -115,11 +108,9 @@ describe("EdcConnectorClient", () => {
     });
 
     it("exposes the custom controller on the client and wires internals", () => {
-      const token = "test-token-123";
       const managementUrl = "https://example.com/management";
 
       const client = new EdcConnectorClient.Builder()
-        .apiToken(token)
         .managementUrl(managementUrl)
         .use("foo", FooController)
         .build();
@@ -129,9 +120,6 @@ describe("EdcConnectorClient", () => {
 
       const context = client.foo.getContext();
       expect(context).toBeInstanceOf(EdcConnectorClientContext);
-
-      expect(context?.apiToken).toBe(token);
-
       expect(context?.management).toBe(managementUrl);
     });
   });


### PR DESCRIPTION
### What
Permit header name configuration for authorization.

Add a new `authorization` method on the builder that receives both the header name and the header value. the already existing `apiToken` has been deprecated

Closes #214 