### PR TITLE
feat: management json-ld context customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,47 @@ const result = await client.management.assets.create(context, {
 });
 ```
 
+### Customizing the JSON-LD Context
+
+Management request bodies include an `@context` field whose value is derived automatically from the configured `managementApiVersion` (a `{ "@vocab": ... }` object for v3, a URL array for any other version). When a connector requires a different context value, it can be overridden with `managementJsonLdContext`.
+
+The option accepts a plain URL string, an array of URLs, or a full JSON-LD context object:
+
+**Via the builder:**
+```ts
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client";
+
+// string URL
+const client = new EdcConnectorClient.Builder()
+  .managementUrl("https://edc.think-it.io/management")
+  .managementJsonLdContext("https://custom.example.com/context/v1")
+  .build();
+
+// JSON-LD context object
+const client = new EdcConnectorClient.Builder()
+  .managementUrl("https://edc.think-it.io/management")
+  .managementJsonLdContext({ "@vocab": "https://custom.example.com/ns/" })
+  .build();
+
+// array of context URLs
+const client = new EdcConnectorClient.Builder()
+  .managementUrl("https://edc.think-it.io/management")
+  .managementJsonLdContext(["https://ctx1.example.com", "https://ctx2.example.com"])
+  .build();
+```
+
+**Via `createContext`:**
+```ts
+import { EdcConnectorClient } from "@think-it-labs/edc-connector-client";
+
+const context = EdcConnectorClient.createContext({
+  addresses: { management: "https://edc.think-it.io/management" },
+  managementJsonLdContext: "https://custom.example.com/context/v1",
+});
+```
+
+When `managementJsonLdContext` is set it takes precedence over the version-based default for every management request made with that client or context.
+
 ### Extending the Client with Custom Controllers
 
 The client can be extended with custom controllers using the `use` method. This feature allows you to add your own functionality while maintaining type safety through the `EdcController` base class. The extension system is designed to be middleware-like, where each controller is lazily instantiated when accessed.

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,6 @@
 import { Class } from "type-fest";
 import { version } from "../package.json";
-import { EdcConnectorClientContext } from "./context";
+import { EdcConnectorClientContext, ManagementJsonLdContext } from "./context";
 import { ObservabilityController } from "./controllers";
 import { PresentationController } from "./controllers/presentation-controller";
 import { EdcController } from "./edc-controller";
@@ -19,6 +19,7 @@ export type ContextInput = {
   managementApiVersion?: string;
   identityApiVersion?: string;
   authorization?: Record<string, string> | undefined;
+  managementJsonLdContext?: ManagementJsonLdContext;
 };
 
 const apiTokenSymbol = Symbol("[#apiToken]");
@@ -28,6 +29,7 @@ const protocolVersionSymbol = Symbol("[#protocolVersion]");
 const managementApiVersionSymbol = Symbol("[#managementApiVersion]");
 const identityApiVersionSymbol = Symbol("[#identityApiVersion]");
 const authorization = Symbol("[#authorization]");
+const managementJsonLdContextSymbol = Symbol("[#managementJsonLdContext]");
 
 class Builder<T extends Record<string, EdcController> = {}> {
   #instance = new EdcConnectorClient();
@@ -37,6 +39,7 @@ class Builder<T extends Record<string, EdcController> = {}> {
   [managementApiVersionSymbol]?: string;
   [identityApiVersionSymbol]?: string;
   [authorization]?: Record<string, string>;
+  [managementJsonLdContextSymbol]?: ManagementJsonLdContext;
 
   /**
    * @deprecated use authorization instead
@@ -91,6 +94,11 @@ class Builder<T extends Record<string, EdcController> = {}> {
     return this;
   }
 
+  managementJsonLdContext(contextUrl: ManagementJsonLdContext): this {
+    this[managementJsonLdContextSymbol] = contextUrl;
+    return this;
+  }
+
   use<K extends string, C extends EdcController>(
     key: K,
     Controller: Class<C>,
@@ -115,6 +123,7 @@ class Builder<T extends Record<string, EdcController> = {}> {
       protocolVersion: this[protocolVersionSymbol],
       managementApiVersion: this[managementApiVersionSymbol],
       identityApiVersion: this[identityApiVersionSymbol],
+      managementJsonLdContext: this[managementJsonLdContextSymbol],
     });
 
     return this.#instance as EdcConnectorClient & T;
@@ -156,6 +165,7 @@ export class EdcConnectorClient {
       managementApiVersion,
       identityApiVersion,
       authorization,
+      managementJsonLdContext,
     }: ContextInput = {
       addresses: {},
     },
@@ -166,6 +176,7 @@ export class EdcConnectorClient {
       managementApiVersion,
       identityApiVersion,
       authorization,
+      managementJsonLdContext,
     );
   }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,12 +4,18 @@ import {
   DEFAULT_MANAGEMENT_API_VERSION,
 } from "./entities";
 
+export type ManagementJsonLdContext =
+  | string
+  | string[]
+  | Record<string, unknown>;
+
 export class EdcConnectorClientContext implements Addresses {
   #authorization: Record<string, string> | undefined;
   #addresses: Addresses;
   #protocolVersion: string;
   #managementApiVersion: string;
   #identityApiVersion: string;
+  #managementJsonLdContext: ManagementJsonLdContext | undefined;
 
   constructor(
     addresses: Addresses,
@@ -17,12 +23,14 @@ export class EdcConnectorClientContext implements Addresses {
     managementApiVersion = DEFAULT_MANAGEMENT_API_VERSION,
     identityApiVersion = DEFAULT_IDENTITY_API_VERSION,
     authorization?: Record<string, string>,
+    managementJsonLdContext?: ManagementJsonLdContext,
   ) {
     this.#authorization = authorization;
     this.#addresses = addresses;
     this.#protocolVersion = protocolVersion;
     this.#managementApiVersion = managementApiVersion;
     this.#identityApiVersion = identityApiVersion;
+    this.#managementJsonLdContext = managementJsonLdContext;
   }
 
   get default(): string {
@@ -62,6 +70,10 @@ export class EdcConnectorClientContext implements Addresses {
 
   get identityApiVersion(): string {
     return this.#identityApiVersion;
+  }
+
+  get managementJsonLdContext(): ManagementJsonLdContext | undefined {
+    return this.#managementJsonLdContext;
   }
 
   get addresses() {

--- a/src/controllers/management-controllers/management-base-controller.ts
+++ b/src/controllers/management-controllers/management-base-controller.ts
@@ -22,7 +22,14 @@ class ManagementRequestHelper {
     return actualContext;
   }
 
-  getContextUrl({ managementApiVersion }: EdcConnectorClientContext) {
+  getContextUrl({
+    managementApiVersion,
+    managementJsonLdContext,
+  }: EdcConnectorClientContext) {
+    if (managementJsonLdContext !== undefined) {
+      return managementJsonLdContext;
+    }
+
     if (managementApiVersion === "v3") {
       return JSON_LD_DEFAULT_CONTEXT;
     }

--- a/src/entities/context.ts
+++ b/src/entities/context.ts
@@ -1,15 +1,3 @@
-export interface Context {
-  dct?: string;
-  edc: string;
-  dcat?: string;
-  odrl?: string;
-  dspace?: string;
-}
-export interface ContextProperties {
-  "@context": Context;
-  "@type"?: string;
-}
-
 export const EDC_CONTEXT = "https://w3id.org/edc/v0.0.1/ns/";
 export const JSON_LD_DEFAULT_CONTEXT = { "@vocab": EDC_CONTEXT };
 export const MANAGEMENT_V2_CONTEXT =

--- a/tests/edc-client.test.ts
+++ b/tests/edc-client.test.ts
@@ -1,8 +1,11 @@
+import nock = require("nock");
 import {
   Addresses,
   EdcConnectorClient,
   EdcConnectorClientContext,
   EdcController,
+  JSON_LD_DEFAULT_CONTEXT,
+  MANAGEMENT_V2_CONTEXT,
 } from "../src";
 import { Inner } from "../src/inner";
 
@@ -132,6 +135,171 @@ describe("EdcConnectorClient", () => {
       await expect(edcClient.observability.checkHealth()).rejects.not.toThrow(
         "Invalid URL",
       );
+    });
+  });
+
+  describe("managementJsonLdContext", () => {
+    describe("createContext", () => {
+      it("is undefined by default", () => {
+        const context = EdcConnectorClient.createContext({
+          addresses: { management: "http://localhost:19193/management" },
+        });
+        expect(context.managementJsonLdContext).toBeUndefined();
+      });
+
+      it("accepts a string URL", () => {
+        const url = "https://custom.example.com/context/v1";
+        const context = EdcConnectorClient.createContext({
+          addresses: { management: "http://localhost:19193/management" },
+          managementJsonLdContext: url,
+        });
+        expect(context.managementJsonLdContext).toBe(url);
+      });
+
+      it("accepts a JSON-LD context object", () => {
+        const contextObj = { "@vocab": "https://custom.example.com/ns/" };
+        const context = EdcConnectorClient.createContext({
+          addresses: { management: "http://localhost:19193/management" },
+          managementJsonLdContext: contextObj,
+        });
+        expect(context.managementJsonLdContext).toStrictEqual(contextObj);
+      });
+
+      it("accepts an array of URLs", () => {
+        const urls = ["https://ctx1.example.com", "https://ctx2.example.com"];
+        const context = EdcConnectorClient.createContext({
+          addresses: { management: "http://localhost:19193/management" },
+          managementJsonLdContext: urls,
+        });
+        expect(context.managementJsonLdContext).toStrictEqual(urls);
+      });
+    });
+
+    describe("Builder", () => {
+      it("sets managementJsonLdContext on the built context", () => {
+        const url = "https://custom.example.com/context/v1";
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl("http://localhost:19193/management")
+          .managementJsonLdContext(url)
+          .build();
+        expect(client.context.managementJsonLdContext).toBe(url);
+      });
+    });
+
+    describe("request @context", () => {
+      const managementUrl = "http://localhost:19193/management";
+
+      beforeEach(() => {
+        if (!nock.isActive()) {
+          nock.activate();
+        }
+      });
+
+      afterEach(() => {
+        nock.cleanAll();
+        nock.restore();
+      });
+
+      it("uses JSON_LD_DEFAULT_CONTEXT for v3 by default", async () => {
+        let requestBody: any;
+        nock("http://localhost:19193")
+          .post("/management/v3/assets/request", (body) => {
+            requestBody = body;
+            return true;
+          })
+          .reply(200, []);
+
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl(managementUrl)
+          .managementApiVersion("v3")
+          .build();
+
+        await client.management.assets.queryAll();
+
+        expect(requestBody["@context"]).toStrictEqual(JSON_LD_DEFAULT_CONTEXT);
+      });
+
+      it("uses MANAGEMENT_V2_CONTEXT array for non-v3 by default", async () => {
+        let requestBody: any;
+        nock("http://localhost:19193")
+          .post("/management/v4/assets/request", (body) => {
+            requestBody = body;
+            return true;
+          })
+          .reply(200, []);
+
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl(managementUrl)
+          .managementApiVersion("v4")
+          .build();
+
+        await client.management.assets.queryAll();
+
+        expect(requestBody["@context"]).toStrictEqual([MANAGEMENT_V2_CONTEXT]);
+      });
+
+      it("overrides @context with a custom string URL", async () => {
+        const customUrl = "https://custom.example.com/context/v1";
+        let requestBody: any;
+        nock("http://localhost:19193")
+          .post("/management/v3/assets/request", (body) => {
+            requestBody = body;
+            return true;
+          })
+          .reply(200, []);
+
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl(managementUrl)
+          .managementJsonLdContext(customUrl)
+          .build();
+
+        await client.management.assets.queryAll();
+
+        expect(requestBody["@context"]).toBe(customUrl);
+      });
+
+      it("overrides @context with a custom JSON-LD context object", async () => {
+        const customContext = { "@vocab": "https://custom.example.com/ns/" };
+        let requestBody: any;
+        nock("http://localhost:19193")
+          .post("/management/v3/assets/request", (body) => {
+            requestBody = body;
+            return true;
+          })
+          .reply(200, []);
+
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl(managementUrl)
+          .managementJsonLdContext(customContext)
+          .build();
+
+        await client.management.assets.queryAll();
+
+        expect(requestBody["@context"]).toStrictEqual(customContext);
+      });
+
+      it("overrides @context with a custom array of URLs", async () => {
+        const customUrls = [
+          "https://ctx1.example.com",
+          "https://ctx2.example.com",
+        ];
+        let requestBody: any;
+        nock("http://localhost:19193")
+          .post("/management/v3/assets/request", (body) => {
+            requestBody = body;
+            return true;
+          })
+          .reply(200, []);
+
+        const client = new EdcConnectorClient.Builder()
+          .managementUrl(managementUrl)
+          .managementJsonLdContext(customUrls)
+          .build();
+
+        await client.management.assets.queryAll();
+
+        expect(requestBody["@context"]).toStrictEqual(customUrls);
+      });
     });
   });
 });


### PR DESCRIPTION
### What
Adds a customizable `managementJsonLdContext` attribute in the client, so the `@context` used for the management calls can be overridden if needs. If not set, the default upstream one will be used

Closes #650 